### PR TITLE
Remove non-existent example reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ cargo test
 
 # Try the recursive rules demo
 cargo run < demo_recursive.txt
-
-# Run examples
-cargo run --example embedded
 ```
 
 ## Datalog Query Language (Phase 3 - Working!)


### PR DESCRIPTION
## Fix Documentation Error

Removes reference to `cargo run --example embedded` from README.md since there are no example targets defined in the project.

### Changes
- Removed the line `cargo run --example embedded` from Quick Start section
- No examples directory or `[[example]]` targets exist in the project

### Verification
- Documentation now only references commands that actually work
- All other commands in the section are valid

Small fix to improve user experience and avoid confusion.
