### PR TITLE
Potential fix for code scanning alert no. 72: Cleartext logging of sensitive information

### DIFF
--- a/src/query/datalog/parser.rs
+++ b/src/query/datalog/parser.rs
@@ -310,7 +310,7 @@ impl Parser {
                         if let Some(Token::String(uuid_str)) = self.advance() {
                             match Uuid::parse_str(&uuid_str) {
                                 Ok(uuid) => Ok(EdnValue::Uuid(uuid)),
-                                Err(_) => Err(format!("Invalid UUID: {}", uuid_str)),
+                                Err(_) => Err("Invalid UUID".to_string()),
                             }
                         } else {
                             Err("Expected UUID string after #uuid tag".to_string())


### PR DESCRIPTION
Potential fix for [https://github.com/adityamukho/minigraf/security/code-scanning/72](https://github.com/adityamukho/minigraf/security/code-scanning/72)

In general, the problem is that parser error strings include raw user input (e.g., the invalid UUID string), and the REPL logs those errors with `eprintln!`. To fix this without changing existing functionality, we should stop including untrusted, potentially sensitive values directly in errors that are logged. Instead, we should emit generic or redacted error messages that convey what went wrong without echoing specific user-supplied values.

The most effective minimal fix along the identified path is:

1. In `src/query/datalog/parser.rs`, change the specific `Err(format!("Invalid UUID: {}", uuid_str))` to a generic message that does not include `uuid_str`, e.g., `Err("Invalid UUID".to_string())`. This removes the only place where a UUID string is directly embedded in the error.
2. Optionally, we can also generalize other error messages that include user-controlled tokens like command names; however, the CodeQL trace is specifically pointing via `EdnValue::Uuid(uuid)` and the UUID parsing error, so the key fix is that UUID error message.
3. In `src/repl.rs`, we keep logging parse errors but only print whatever sanitized message the parser now returns. Since we’re not asked to change the overall behavior of the REPL, we will leave `eprintln!("Parse error: {}", e);` intact; its content is now less likely to contain sensitive identifiers.

No new methods or imports are needed; we only adjust the error string literal in the parser at the UUID handling site.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
