### PR TITLE
Potential fix for code scanning alert no. 72: Cleartext logging of sensitive information

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -100,8 +100,8 @@ impl Repl {
                                     eprintln!("Execution error: {}", e);
                                 }
                             },
-                            Err(e) => {
-                                eprintln!("Parse error: {}", e);
+                            Err(_e) => {
+                                eprintln!("Parse error");
                             }
                         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/adityamukho/minigraf/security/code-scanning/72](https://github.com/adityamukho/minigraf/security/code-scanning/72)

In general, to fix cleartext logging of sensitive information, avoid logging raw untrusted data (like full user-provided values or IDs). If you need diagnostics, either (a) replace detailed messages with generic ones that don’t include user content, or (b) sanitize/redact before logging. For a REPL, generic high-level errors are usually sufficient.

For this specific case, the problematic behavior is that `parse_datalog_command(&command_buffer)` returns `Err(String)` where the `String` may contain user data, and `repl.rs` logs that entire string to stderr. The least invasive fix that preserves functionality is to keep parse-time diagnostics in the Rust type system (the `Err(String)`), but avoid echoing the error details to the user. Instead, print a generic message like `"Parse error"` that reveals only that parsing failed, without including the inner string `e`. This does not change control flow, error handling, or any non-logging behavior; it only reduces the information exposed over the logging channel.

Concretely:
- In `src/repl.rs`, in the `Err(e)` arm of the `parse_datalog_command` match (around lines 103–105), change `eprintln!("Parse error: {}", e);` to a generic message `eprintln!("Parse error");`.
- No changes are needed in `src/query/datalog/parser.rs` or `src/query/datalog/types.rs`, because they don’t themselves perform logging; they only construct error strings.
- No additional methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
