### PR TITLE
fix: WAL header uses sync_all instead of flush

### DIFF
--- a/src/wal.rs
+++ b/src/wal.rs
@@ -38,7 +38,7 @@ fn write_wal_header(file: &mut File) -> Result<()> {
     // bytes 8..32 are reserved zeros
     file.seek(SeekFrom::Start(0))?;
     file.write_all(&buf)?;
-    file.flush()?;
+    file.sync_all()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Changed `file.flush()` to `file.sync_all()` in `write_wal_header` to ensure WAL header data is persisted to disk, not just moved to OS buffers
- Fixes issue #38