### PR TITLE
fix(query): pre-compile regex patterns at parse time (issue #36)

### DIFF
--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -13,7 +13,6 @@ use crate::graph::FactStorage;
 use crate::graph::types::{Fact, TransactOptions, TxId, Value, tx_id_now};
 use crate::storage::index::Indexes;
 use anyhow::{Result, anyhow};
-use regex_lite::Regex;
 use std::sync::{Arc, RwLock};
 
 /// Returns true if any where clause (at any depth) contains a per-fact
@@ -1331,12 +1330,8 @@ fn eval_binop(op: &BinOp, l: Value, r: Value) -> Result<Value, ()> {
             }
             _ => Err(()),
         },
-        BinOp::Matches => match (l, r) {
-            (Value::String(s), Value::String(pattern)) => {
-                // Pattern was validated at parse time; compile here.
-                let re = Regex::new(&pattern).map_err(|_| ())?;
-                Ok(Value::Boolean(re.is_match(&s)))
-            }
+        BinOp::Matches { regex: re, .. } => match (l, r) {
+            (Value::String(s), Value::String(_)) => Ok(Value::Boolean(re.is_match(&s))),
             _ => Err(()),
         },
 
@@ -3067,8 +3062,12 @@ mod expr_eval_tests {
 
     #[test]
     fn test_eval_matches_true() {
+        let re = regex_lite::Regex::new("^[^@]+@[^@]+$").unwrap();
         let e = Expr::BinOp(
-            BinOp::Matches,
+            BinOp::Matches {
+                regex: re,
+                pattern: "^[^@]+@[^@]+$".to_string(),
+            },
             Box::new(Expr::Lit(Value::String("test@example.com".to_string()))),
             Box::new(Expr::Lit(Value::String("^[^@]+@[^@]+$".to_string()))),
         );

--- a/src/query/datalog/parser.rs
+++ b/src/query/datalog/parser.rs
@@ -1031,6 +1031,29 @@ fn parse_expr(list: &[EdnValue]) -> Result<Expr, String> {
             if list.len() != 3 {
                 return Err(format!("{} takes exactly 2 arguments", head));
             }
+            // matches? second arg must be a string literal; compile regex early.
+            if head == "matches?" {
+                let lhs = parse_expr_arg(&list[1])?;
+                let rhs = parse_expr_arg(&list[2])?;
+                match &rhs {
+                    Expr::Lit(Value::String(pattern)) => {
+                        let compiled = regex_lite::Regex::new(pattern)
+                            .map_err(|e| format!("invalid regex pattern {:?}: {}", pattern, e))?;
+                        let rhs_lit = Expr::Lit(Value::String(pattern.clone()));
+                        return Ok(Expr::BinOp(
+                            BinOp::Matches {
+                                regex: compiled,
+                                pattern: pattern.clone(),
+                            },
+                            Box::new(lhs),
+                            Box::new(rhs_lit),
+                        ));
+                    }
+                    _ => {
+                        return Err("matches? second argument must be a string literal".to_string());
+                    }
+                }
+            }
             let op = match head {
                 "<" => BinOp::Lt,
                 ">" => BinOp::Gt,
@@ -1045,24 +1068,10 @@ fn parse_expr(list: &[EdnValue]) -> Result<Expr, String> {
                 "starts-with?" => BinOp::StartsWith,
                 "ends-with?" => BinOp::EndsWith,
                 "contains?" => BinOp::Contains,
-                "matches?" => BinOp::Matches,
                 _ => unreachable!(),
             };
             let lhs = parse_expr_arg(&list[1])?;
             let rhs = parse_expr_arg(&list[2])?;
-
-            // matches? second arg must be a string literal; validate regex now.
-            if op == BinOp::Matches {
-                match &rhs {
-                    Expr::Lit(Value::String(pattern)) => {
-                        regex_lite::Regex::new(pattern)
-                            .map_err(|e| format!("invalid regex pattern {:?}: {}", pattern, e))?;
-                    }
-                    _ => {
-                        return Err("matches? second argument must be a string literal".to_string());
-                    }
-                }
-            }
             Ok(Expr::BinOp(op, Box::new(lhs), Box::new(rhs)))
         }
 

--- a/src/query/datalog/types.rs
+++ b/src/query/datalog/types.rs
@@ -144,7 +144,9 @@ impl WindowSpec {
 }
 
 /// Binary operators for expression clauses.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// Manual impl for PartialEq/Eq/Hash because `Matches` holds a `regex_lite::Regex`
+/// which doesn't implement these traits.
+#[derive(Debug, Clone)]
 pub enum BinOp {
     // Comparisons — return Boolean
     Lt,
@@ -163,7 +165,34 @@ pub enum BinOp {
     EndsWith,
     Contains,
     /// Pattern must be a string literal validated at parse time via regex-lite.
-    Matches,
+    /// The compiled `regex_lite::Regex` is stored alongside the original string pattern.
+    Matches {
+        regex: regex_lite::Regex,
+        pattern: String,
+    },
+}
+
+impl PartialEq for BinOp {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (BinOp::Matches { pattern: p1, .. }, BinOp::Matches { pattern: p2, .. }) => p1 == p2,
+            (a, b) => std::mem::discriminant(a) == std::mem::discriminant(b),
+        }
+    }
+}
+
+impl Eq for BinOp {}
+
+impl std::hash::Hash for BinOp {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            BinOp::Matches { pattern, .. } => {
+                core::hash::Hash::hash(&0u8, state);
+                core::hash::Hash::hash(pattern, state);
+            }
+            _ => core::hash::Hash::hash(&std::mem::discriminant(self), state),
+        }
+    }
 }
 
 /// Unary type-predicate operators — always return Boolean.
@@ -1085,7 +1114,6 @@ mod tests {
         let _ = BinOp::StartsWith;
         let _ = BinOp::EndsWith;
         let _ = BinOp::Contains;
-        let _ = BinOp::Matches;
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Pre-compile regex patterns at parse time instead of on every match evaluation
- Modified `BinOp::Matches` to hold a pre-compiled `regex_lite::Regex` + pattern string for equality/hashing
- Updated parser to compile regex early (after validation) in `parse_expr`
- Updated executor to use the pre-compiled regex directly in `eval_binop`

This fixes the performance issue where regex was being compiled for every binding evaluation during query execution.