### PR TITLE
test(error_handling): unignore or-negative-cycle test (issue #74)

### DIFF
--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -68,7 +68,6 @@ fn negative_cycle_pair_rejected() {
 
 /// An or branch that creates a negative cycle must also be rejected.
 #[test]
-#[ignore = "bug: or-with-negative-cycle not rejected by stratification"]
 fn or_negative_cycle_rejected() {
     let db = db();
     // base rule: safe depends on not-unsafe


### PR DESCRIPTION
## Summary
- Removed `#[ignore]` attribute from `or_negative_cycle_rejected` test in `tests/error_handling_test.rs`
- The test passes because the stratification code already correctly handles Or/OrJoin branches by recursively collecting dependencies
- The stratifier correctly detects negative cycles that pass through `or` clauses

The issue description indicated this was a bug, but investigation shows the stratifier was already working correctly. The test was incorrectly marked as ignored.