### PR TITLE
ci(bench): add compile job with target cache to light benchmark workflow

### DIFF
--- a/.github/workflows/bench_light.yml
+++ b/.github/workflows/bench_light.yml
@@ -10,9 +10,40 @@ permissions:
   issues: write
 
 jobs:
+  compile:
+    name: bench / compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      - name: Cache bench target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-bench-light-target-${{ hashFiles('**/Cargo.lock', 'benches/**', 'src/**/*.rs') }}
+
+      - name: Compile benchmarks
+        run: cargo bench --no-run
+
   benchmark:
     name: bench / ${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: [compile]
     timeout-minutes: 360
     strategy:
       fail-fast: false   # one timeout must not cancel sibling jobs
@@ -109,6 +140,12 @@ jobs:
           key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-bench-
+
+      - name: Restore bench target
+        uses: actions/cache/restore@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-bench-light-target-${{ hashFiles('**/Cargo.lock', 'benches/**', 'src/**/*.rs') }}
 
       - name: Run benchmarks (${{ matrix.name }})
         run: |


### PR DESCRIPTION
## Summary

- `bench_light.yml` had no `compile` job — each of its 12 matrix jobs compiled the bench binary from scratch independently, wasting ~12-24 minutes of redundant compilation per nightly run
- The cargo registry cache key only hashed `Cargo.lock`, so source changes to `benches/**` or `src/**/*.rs` could still reuse a stale binary

## Changes

- Add a `compile` job (mirrors `bench.yml`): builds once with `cargo bench --no-run`, saves `target/` via `actions/cache`
- `benchmark` job gains `needs: [compile]` and restores the pre-built binary via `actions/cache/restore` instead of recompiling
- Cache key includes `benches/**` and `src/**/*.rs` (same fix as #122) to invalidate on source changes
- Uses a distinct cache key prefix (`bench-light-target-`) to avoid racing with `bench.yml`'s cache writes — both workflows are scheduled at `0 2 * * *`

## Test plan

- [x] Pre-push hook (fmt + clippy + test) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)