### PR TITLE
perf(db): replace transactional query view rebuild with merged fact slice

### DIFF
--- a/docs/superpowers/specs/2026-04-08-issue-96-overlay-query-view-design.md
+++ b/docs/superpowers/specs/2026-04-08-issue-96-overlay-query-view-design.md
@@ -1,0 +1,87 @@
+# Issue 96 Overlay Query View Design
+
+**Goal:** Remove the full `FactStorage` deep-copy/reindex path from `WriteTransaction` read-your-own-writes queries without changing public API or query semantics.
+
+**Non-goals:**
+- No API changes in `Minigraf`, `WriteTransaction`, or query types
+- No behavior changes for commit, rollback, rule registration, or transaction visibility
+- No broad query engine refactor beyond what is needed to avoid the rebuild
+
+## Problem
+
+`WriteTransaction::execute()` currently routes `Query` and `Rule` commands through `build_query_view()`, which materializes a fresh `FactStorage` by:
+
+1. loading all committed facts from the shared store
+2. rebuilding pending indexes in the temporary store
+3. appending the transaction's buffered facts
+
+That makes every transactional read with pending writes pay an O(N) copy/reindex cost over committed state.
+
+## Constraints
+
+- Transactional reads must still see committed facts plus all buffered facts in the current transaction
+- Retractions, temporal filters, pseudo-attributes, prepared query behavior, and rule evaluation results must remain unchanged
+- The shared `FactStorage` must not be mutated by transactional reads
+- The fix should stay internal and keep the code understandable
+
+## Proposed Approach
+
+Introduce a lightweight transactional query path that operates on a merged fact slice instead of a rebuilt `FactStorage`.
+
+### Query path split
+
+- Keep the existing fast path when `pending_facts` is empty: reuse `self.inner.fact_storage.clone()`
+- When `pending_facts` is non-empty:
+  - gather committed facts from the shared store
+  - append cloned pending facts into one contiguous `Arc<[Fact]>`
+  - execute the query against that merged slice
+
+### Execution strategy
+
+- Add a transaction-focused execution helper in the Datalog executor layer that accepts an `Arc<[Fact]>`
+- Reuse the existing slice-based query machinery already used by non-rules query execution where possible
+- For rule-aware transactional reads, build only the minimum adapter required for the evaluator path rather than rebuilding indexes eagerly for every read
+
+### Safety and semantics
+
+- The merged fact slice is read-only and transaction-local
+- Ordering remains append-only: committed facts first, pending facts after
+- Existing filtering rules still determine visible state, including net assertions/retractions and temporal windows
+
+## File Impact
+
+- `src/db.rs`
+  - replace the deep-copy transactional read path
+  - remove or narrow `build_query_view()`
+- `src/query/datalog/executor.rs`
+  - add or extend a helper for executing from an `Arc<[Fact]>` in the transactional path
+- `tests` / `src/db.rs` unit tests
+  - add regression coverage proving transactional reads still work and the old rebuild path is no longer required
+
+## Testing Plan
+
+TDD order:
+
+1. Add a failing regression test for transactional query execution with pending writes
+2. Verify the test fails for the intended reason
+3. Implement the slice/overlay query path
+4. Re-run the focused test
+5. Run broader transactional and query suites
+
+Focused verification targets:
+
+- `cargo test db::tests::test_write_transaction_read_your_own_writes -- --nocapture`
+- relevant query tests if executor changes require them
+- full `cargo test` before completion
+
+## Risks
+
+- Rule evaluation still expects storage-oriented inputs in some paths; the fix must not accidentally reintroduce the same copy through a different helper
+- Merged-slice execution must preserve the same temporal and retraction semantics as the current storage-backed path
+
+## Success Criteria
+
+- No public API changes
+- Transactional reads with pending facts no longer rebuild a full temporary `FactStorage`
+- Existing read-your-own-writes behavior remains intact
+- Tests pass in the issue worktree

--- a/src/db.rs
+++ b/src/db.rs
@@ -844,18 +844,12 @@ impl<'a> WriteTransaction<'a> {
                 self.pending_facts.extend(new_facts);
                 Ok(QueryResult::Ok)
             }
-            DatalogCommand::Query(_) | DatalogCommand::Rule(_) => {
-                // For queries: build a temporary FactStorage that includes
-                // committed facts + buffered pending facts (read-your-own-writes).
-                let view = self.build_query_view()?;
-                let executor = DatalogExecutor::new_with_rules_and_functions(
-                    view,
-                    self.inner.rules.clone(),
-                    self.inner.functions.clone(),
-                );
-                executor.execute(cmd)
-            }
+            DatalogCommand::Query(_) | DatalogCommand::Rule(_) => self.execute_read_command(cmd),
         }
+    }
+
+    fn execute_read_command(&self, _cmd: DatalogCommand) -> Result<QueryResult> {
+        unimplemented!("transactional slice-backed read path not implemented yet")
     }
 
     /// Commit this transaction atomically.
@@ -1113,6 +1107,29 @@ mod tests {
         }
 
         tx.commit().unwrap();
+    }
+
+    #[test]
+    fn test_write_transaction_query_with_pending_retraction_and_assertion() {
+        let db = Minigraf::in_memory().unwrap();
+        db.execute(r#"(transact [[:alice :person/name "Alice"] [:alice :person/age 30]])"#)
+            .unwrap();
+
+        let mut tx = db.begin_write().unwrap();
+        tx.execute(r#"(retract [[:alice :person/age 30]])"#).unwrap();
+        tx.execute(r#"(transact [[:alice :person/age 31]])"#).unwrap();
+
+        let result = tx
+            .execute(r#"(query [:find ?age :where [:alice :person/age ?age]])"#)
+            .unwrap();
+
+        match result {
+            QueryResult::QueryResults { results, .. } => {
+                assert_eq!(results.len(), 1, "should see only one visible age");
+                assert_eq!(results[0][0], Value::Integer(31));
+            }
+            _ => panic!("expected QueryResults"),
+        }
     }
 
     // ── thread-local flag: same-thread reentrant error ────────────────────────

--- a/src/db.rs
+++ b/src/db.rs
@@ -903,9 +903,9 @@ impl<'a> WriteTransaction<'a> {
         self.pending_facts.extend(facts.into_iter().map(|mut fact| {
             fact.tx_id = staged_tx_id;
             fact.tx_count = staged_tx_count;
-            if fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME {
-                fact.valid_from = staged_tx_id as i64;
-            } else if !fact.asserted && fact.valid_from == 0 {
+            if (fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME)
+                || (!fact.asserted && fact.valid_from == 0)
+            {
                 fact.valid_from = staged_tx_id as i64;
             }
             fact

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,7 +6,7 @@
 //! - `Minigraf::begin_write()` / `WriteTransaction` for explicit transactions
 //! - `Minigraf::checkpoint()` for manual WAL compaction
 
-use crate::graph::types::{Fact, VALID_TIME_FOREVER};
+use crate::graph::types::{Fact, TxId, VALID_TIME_FOREVER};
 
 /// Sentinel value used in `materialize_transaction` to signal "no explicit `valid_from`
 /// was provided; use the transaction timestamp at commit time."
@@ -510,6 +510,8 @@ impl Minigraf {
             guard,
             inner: &self.inner,
             pending_facts: Vec::new(),
+            read_tx_id: crate::graph::types::tx_id_now(),
+            read_tx_count: self.inner.fact_storage.current_tx_count() + 1,
             committed: false,
         })
     }
@@ -818,6 +820,9 @@ pub struct WriteTransaction<'a> {
     inner: &'a Inner,
     /// Facts buffered in this transaction (not yet committed to FactStorage).
     pending_facts: Vec<Fact>,
+    /// Stable synthetic tx metadata used while reading pending facts.
+    read_tx_id: TxId,
+    read_tx_count: u64,
     /// Set to `true` after a successful `commit()` to suppress rollback in `Drop`.
     committed: bool,
 }
@@ -844,7 +849,8 @@ impl<'a> WriteTransaction<'a> {
                 self.pending_facts.extend(new_facts);
                 Ok(QueryResult::Ok)
             }
-            DatalogCommand::Query(_) | DatalogCommand::Rule(_) => self.execute_read_command(cmd),
+            DatalogCommand::Query(_) => self.execute_read_command(cmd),
+            DatalogCommand::Rule(rule) => self.execute_rule_command(rule),
         }
     }
 
@@ -873,6 +879,19 @@ impl<'a> WriteTransaction<'a> {
             self.inner.options.max_results,
         );
         executor.execute(cmd)
+    }
+
+    fn execute_rule_command(&self, rule: crate::query::datalog::types::Rule) -> Result<QueryResult> {
+        let mut executor = DatalogExecutor::new_with_rules_and_functions(
+            self.inner.fact_storage.clone(),
+            self.inner.rules.clone(),
+            self.inner.functions.clone(),
+        );
+        executor.set_limits(
+            self.inner.options.max_derived_facts,
+            self.inner.options.max_results,
+        );
+        executor.execute(DatalogCommand::Rule(rule))
     }
 
     /// Commit this transaction atomically.
@@ -981,14 +1000,13 @@ impl<'a> WriteTransaction<'a> {
         let mut merged = Vec::with_capacity(committed.len() + self.pending_facts.len());
         merged.extend(committed);
 
-        let overlay_tx_id = crate::graph::types::tx_id_now();
-        let overlay_tx_count = self.inner.fact_storage.current_tx_count() + 1;
+        let overlay_tx_count = self.read_tx_count;
 
         merged.extend(self.pending_facts.iter().cloned().map(|mut fact| {
-            fact.tx_id = overlay_tx_id;
+            fact.tx_id = self.read_tx_id;
             fact.tx_count = overlay_tx_count;
             if fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME {
-                fact.valid_from = overlay_tx_id as i64;
+                fact.valid_from = self.read_tx_id as i64;
             }
             fact
         }));
@@ -1157,6 +1175,46 @@ mod tests {
                     results.iter().any(|row| row[0] == Value::Keyword(":c".to_string())),
                     "rule query should see pending edge"
                 );
+            }
+            _ => panic!("expected QueryResults"),
+        }
+    }
+
+    #[test]
+    fn test_write_transaction_pending_metadata_is_stable_across_reads() {
+        use std::time::Duration;
+
+        let db = Minigraf::in_memory().unwrap();
+        let mut tx = db.begin_write().unwrap();
+        tx.execute(r#"(transact [[:alice :person/name "Alice"]])"#)
+            .unwrap();
+
+        let first = tx
+            .execute(
+                r#"(query [:find ?tx ?vf :any-valid-time :where [:alice :db/tx-id ?tx] [:alice :db/valid-from ?vf]])"#,
+            )
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(3));
+        let second = tx
+            .execute(
+                r#"(query [:find ?tx ?vf :any-valid-time :where [:alice :db/tx-id ?tx] [:alice :db/valid-from ?vf]])"#,
+            )
+            .unwrap();
+
+        match (first, second) {
+            (
+                QueryResult::QueryResults {
+                    results: first_results,
+                    ..
+                },
+                QueryResult::QueryResults {
+                    results: second_results,
+                    ..
+                },
+            ) => {
+                assert_eq!(first_results.len(), 1);
+                assert_eq!(second_results.len(), 1);
+                assert_eq!(first_results[0], second_results[0]);
             }
             _ => panic!("expected QueryResults"),
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -905,11 +905,6 @@ impl<'a> WriteTransaction<'a> {
         self.pending_facts.extend(facts.into_iter().map(|mut fact| {
             fact.tx_id = staged_tx_id;
             fact.tx_count = staged_tx_count;
-            if (fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME)
-                || (!fact.asserted && fact.valid_from == 0)
-            {
-                fact.valid_from = staged_tx_id as i64;
-            }
             fact
         }));
 
@@ -1018,11 +1013,21 @@ impl<'a> WriteTransaction<'a> {
     }
 
     /// Build a merged fact snapshot for transactional reads.
+    ///
+    /// Pending facts still carry `VALID_FROM_USE_TX_TIME` for assertions where no
+    /// explicit `valid_from` was supplied (the sentinel is left intact so `commit()`
+    /// can stamp it with the real commit timestamp).  We resolve it here using each
+    /// fact's own staged `tx_id` so transactional queries see a coherent valid-time.
     fn merged_query_facts(&self) -> Result<Arc<[Fact]>> {
         let committed = self.inner.fact_storage.get_all_facts()?;
         let mut merged = Vec::with_capacity(committed.len() + self.pending_facts.len());
         merged.extend(committed);
-        merged.extend(self.pending_facts.iter().cloned());
+        merged.extend(self.pending_facts.iter().cloned().map(|mut f| {
+            if f.asserted && f.valid_from == VALID_FROM_USE_TX_TIME {
+                f.valid_from = f.tx_id as i64;
+            }
+            f
+        }));
         Ok(Arc::from(merged))
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -510,8 +510,8 @@ impl Minigraf {
             guard,
             inner: &self.inner,
             pending_facts: Vec::new(),
-            read_tx_id: crate::graph::types::tx_id_now(),
-            read_tx_count: self.inner.fact_storage.current_tx_count() + 1,
+            next_pending_tx_count: self.inner.fact_storage.current_tx_count() + 1,
+            next_pending_tx_id: crate::graph::types::tx_id_now(),
             committed: false,
         })
     }
@@ -820,9 +820,10 @@ pub struct WriteTransaction<'a> {
     inner: &'a Inner,
     /// Facts buffered in this transaction (not yet committed to FactStorage).
     pending_facts: Vec<Fact>,
-    /// Stable synthetic tx metadata used while reading pending facts.
-    read_tx_id: TxId,
-    read_tx_count: u64,
+    /// Synthetic tx_count assigned to the next staged write batch.
+    next_pending_tx_count: u64,
+    /// Synthetic tx_id seed used to keep staged writes monotonic.
+    next_pending_tx_id: TxId,
     /// Set to `true` after a successful `commit()` to suppress rollback in `Drop`.
     committed: bool,
 }
@@ -840,13 +841,11 @@ impl<'a> WriteTransaction<'a> {
 
         match cmd {
             DatalogCommand::Transact(tx) => {
-                let new_facts = Minigraf::materialize_transaction(&tx)?;
-                self.pending_facts.extend(new_facts);
+                self.stage_pending_facts(Minigraf::materialize_transaction(&tx)?);
                 Ok(QueryResult::Ok)
             }
             DatalogCommand::Retract(tx) => {
-                let new_facts = Minigraf::materialize_retraction(&tx)?;
-                self.pending_facts.extend(new_facts);
+                self.stage_pending_facts(Minigraf::materialize_retraction(&tx)?);
                 Ok(QueryResult::Ok)
             }
             DatalogCommand::Query(_) => self.execute_read_command(cmd),
@@ -892,6 +891,27 @@ impl<'a> WriteTransaction<'a> {
             self.inner.options.max_results,
         );
         executor.execute(DatalogCommand::Rule(rule))
+    }
+
+    /// Stage buffered facts with stable synthetic read metadata.
+    fn stage_pending_facts(&mut self, facts: Vec<Fact>) {
+        let staged_tx_id =
+            std::cmp::max(crate::graph::types::tx_id_now(), self.next_pending_tx_id);
+        let staged_tx_count = self.next_pending_tx_count;
+
+        self.pending_facts.extend(facts.into_iter().map(|mut fact| {
+            fact.tx_id = staged_tx_id;
+            fact.tx_count = staged_tx_count;
+            if fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME {
+                fact.valid_from = staged_tx_id as i64;
+            } else if !fact.asserted && fact.valid_from == 0 {
+                fact.valid_from = staged_tx_id as i64;
+            }
+            fact
+        }));
+
+        self.next_pending_tx_id = staged_tx_id.saturating_add(1);
+        self.next_pending_tx_count += 1;
     }
 
     /// Commit this transaction atomically.
@@ -999,17 +1019,7 @@ impl<'a> WriteTransaction<'a> {
         let committed = self.inner.fact_storage.get_all_facts()?;
         let mut merged = Vec::with_capacity(committed.len() + self.pending_facts.len());
         merged.extend(committed);
-
-        let overlay_tx_count = self.read_tx_count;
-
-        merged.extend(self.pending_facts.iter().cloned().map(|mut fact| {
-            fact.tx_id = self.read_tx_id;
-            fact.tx_count = overlay_tx_count;
-            if fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME {
-                fact.valid_from = self.read_tx_id as i64;
-            }
-            fact
-        }));
+        merged.extend(self.pending_facts.iter().cloned());
         Ok(Arc::from(merged))
     }
 }
@@ -1182,39 +1192,67 @@ mod tests {
 
     #[test]
     fn test_write_transaction_pending_metadata_is_stable_across_reads() {
+        use chrono::{SecondsFormat, Utc};
         use std::time::Duration;
 
         let db = Minigraf::in_memory().unwrap();
         let mut tx = db.begin_write().unwrap();
-        tx.execute(r#"(transact [[:alice :person/name "Alice"]])"#)
+        tx.execute(r#"(transact [[:alice :person/age 30]])"#)
             .unwrap();
 
         let first = tx
             .execute(
-                r#"(query [:find ?tx ?vf :any-valid-time :where [:alice :db/tx-id ?tx] [:alice :db/valid-from ?vf]])"#,
+                r#"(query [:find ?tx ?tc ?vf :any-valid-time :where [:alice :person/age ?age] [:alice :db/tx-id ?tx] [:alice :db/tx-count ?tc] [:alice :db/valid-from ?vf]])"#,
             )
             .unwrap();
         std::thread::sleep(Duration::from_millis(3));
         let second = tx
             .execute(
-                r#"(query [:find ?tx ?vf :any-valid-time :where [:alice :db/tx-id ?tx] [:alice :db/valid-from ?vf]])"#,
+                r#"(query [:find ?tx ?tc ?vf :any-valid-time :where [:alice :person/age ?age] [:alice :db/tx-id ?tx] [:alice :db/tx-count ?tc] [:alice :db/valid-from ?vf]])"#,
             )
             .unwrap();
 
-        match (first, second) {
-            (
-                QueryResult::QueryResults {
-                    results: first_results,
-                    ..
-                },
-                QueryResult::QueryResults {
-                    results: second_results,
-                    ..
-                },
-            ) => {
-                assert_eq!(first_results.len(), 1);
+        let (first_row, tx_id) = match &first {
+            QueryResult::QueryResults { results, .. } => {
+                assert_eq!(results.len(), 1);
+                let row = results[0].clone();
+                let tx_id = match row[0] {
+                    Value::Integer(i) => i,
+                    _ => panic!("expected tx id integer"),
+                };
+                assert_eq!(row[1], Value::Integer(1));
+                assert_eq!(row[2], Value::Integer(tx_id));
+                (row, tx_id)
+            }
+            _ => panic!("expected QueryResults"),
+        };
+
+        match second {
+            QueryResult::QueryResults {
+                results: second_results,
+                ..
+            } => {
                 assert_eq!(second_results.len(), 1);
-                assert_eq!(first_results[0], second_results[0]);
+                assert_eq!(first_row, second_results[0]);
+            }
+            _ => panic!("expected QueryResults"),
+        }
+
+        tx.execute(r#"(transact [[:alice :person/age 31]])"#).unwrap();
+
+        let as_of_timestamp = chrono::DateTime::<Utc>::from_timestamp_millis(tx_id)
+            .unwrap()
+            .to_rfc3339_opts(SecondsFormat::Millis, true);
+        let as_of_query = format!(
+            r#"(query [:find ?age :as-of "{}" :where [:alice :person/age ?age]])"#,
+            as_of_timestamp
+        );
+        let as_of_result = tx.execute(&as_of_query).unwrap();
+
+        match as_of_result {
+            QueryResult::QueryResults { results, .. } => {
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0][0], Value::Integer(30));
             }
             _ => panic!("expected QueryResults"),
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -881,7 +881,10 @@ impl<'a> WriteTransaction<'a> {
         executor.execute(cmd)
     }
 
-    fn execute_rule_command(&self, rule: crate::query::datalog::types::Rule) -> Result<QueryResult> {
+    fn execute_rule_command(
+        &self,
+        rule: crate::query::datalog::types::Rule,
+    ) -> Result<QueryResult> {
         let mut executor = DatalogExecutor::new_with_rules_and_functions(
             self.inner.fact_storage.clone(),
             self.inner.rules.clone(),
@@ -896,8 +899,7 @@ impl<'a> WriteTransaction<'a> {
 
     /// Stage buffered facts with stable synthetic read metadata.
     fn stage_pending_facts(&mut self, facts: Vec<Fact>) {
-        let staged_tx_id =
-            std::cmp::max(crate::graph::types::tx_id_now(), self.next_pending_tx_id);
+        let staged_tx_id = std::cmp::max(crate::graph::types::tx_id_now(), self.next_pending_tx_id);
         let staged_tx_count = self.next_pending_tx_count;
 
         self.pending_facts.extend(facts.into_iter().map(|mut fact| {
@@ -1159,8 +1161,10 @@ mod tests {
             .unwrap();
 
         let mut tx = db.begin_write().unwrap();
-        tx.execute(r#"(retract [[:alice :person/age 30]])"#).unwrap();
-        tx.execute(r#"(transact [[:alice :person/age 31]])"#).unwrap();
+        tx.execute(r#"(retract [[:alice :person/age 30]])"#)
+            .unwrap();
+        tx.execute(r#"(transact [[:alice :person/age 31]])"#)
+            .unwrap();
 
         let result = tx
             .execute(r#"(query [:find ?age :where [:alice :person/age ?age]])"#)
@@ -1182,7 +1186,8 @@ mod tests {
             .unwrap();
 
         let mut tx = db.begin_write().unwrap();
-        tx.execute(r#"(retract [[:alice :person/age 30]])"#).unwrap();
+        tx.execute(r#"(retract [[:alice :person/age 30]])"#)
+            .unwrap();
 
         let result = tx
             .execute(r#"(query [:find ?age :where [:alice :person/age ?age]])"#)
@@ -1190,7 +1195,11 @@ mod tests {
 
         match result {
             QueryResult::QueryResults { results, .. } => {
-                assert_eq!(results.len(), 0, "retracted committed fact must not be visible");
+                assert_eq!(
+                    results.len(),
+                    0,
+                    "retracted committed fact must not be visible"
+                );
             }
             _ => panic!("expected QueryResults"),
         }
@@ -1199,7 +1208,8 @@ mod tests {
     #[test]
     fn test_write_transaction_rule_query_with_pending_write() {
         let db = Minigraf::in_memory().unwrap();
-        db.execute("(rule [(reachable ?x ?y) [?x :edge ?y]])").unwrap();
+        db.execute("(rule [(reachable ?x ?y) [?x :edge ?y]])")
+            .unwrap();
         db.execute("(rule [(reachable ?x ?y) [?x :edge ?z] (reachable ?z ?y)])")
             .unwrap();
         db.execute("(transact [[:a :edge :b]])").unwrap();
@@ -1207,12 +1217,16 @@ mod tests {
         let mut tx = db.begin_write().unwrap();
         tx.execute("(transact [[:b :edge :c]])").unwrap();
 
-        let result = tx.execute("(query [:find ?y :where (reachable :a ?y)])").unwrap();
+        let result = tx
+            .execute("(query [:find ?y :where (reachable :a ?y)])")
+            .unwrap();
 
         match result {
             QueryResult::QueryResults { results, .. } => {
                 assert!(
-                    results.iter().any(|row| row[0] == Value::Keyword(":c".to_string())),
+                    results
+                        .iter()
+                        .any(|row| row[0] == Value::Keyword(":c".to_string())),
                     "rule query should see pending edge"
                 );
             }
@@ -1268,7 +1282,8 @@ mod tests {
             _ => panic!("expected QueryResults"),
         }
 
-        tx.execute(r#"(transact [[:alice :person/age 31]])"#).unwrap();
+        tx.execute(r#"(transact [[:alice :person/age 31]])"#)
+            .unwrap();
 
         let future_tx_id = tx_id as u64 + 60_000;
         let future_fact = Fact::with_valid_time(

--- a/src/db.rs
+++ b/src/db.rs
@@ -1176,6 +1176,27 @@ mod tests {
     }
 
     #[test]
+    fn test_write_transaction_pending_retraction_only_hides_committed_fact() {
+        let db = Minigraf::in_memory().unwrap();
+        db.execute(r#"(transact [[:alice :person/age 30]])"#)
+            .unwrap();
+
+        let mut tx = db.begin_write().unwrap();
+        tx.execute(r#"(retract [[:alice :person/age 30]])"#).unwrap();
+
+        let result = tx
+            .execute(r#"(query [:find ?age :where [:alice :person/age ?age]])"#)
+            .unwrap();
+
+        match result {
+            QueryResult::QueryResults { results, .. } => {
+                assert_eq!(results.len(), 0, "retracted committed fact must not be visible");
+            }
+            _ => panic!("expected QueryResults"),
+        }
+    }
+
+    #[test]
     fn test_write_transaction_rule_query_with_pending_write() {
         let db = Minigraf::in_memory().unwrap();
         db.execute("(rule [(reachable ?x ?y) [?x :edge ?y]])").unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -848,8 +848,31 @@ impl<'a> WriteTransaction<'a> {
         }
     }
 
-    fn execute_read_command(&self, _cmd: DatalogCommand) -> Result<QueryResult> {
-        unimplemented!("transactional slice-backed read path not implemented yet")
+    fn execute_read_command(&self, cmd: DatalogCommand) -> Result<QueryResult> {
+        if self.pending_facts.is_empty() {
+            let mut executor = DatalogExecutor::new_with_rules_and_functions(
+                self.inner.fact_storage.clone(),
+                self.inner.rules.clone(),
+                self.inner.functions.clone(),
+            );
+            executor.set_limits(
+                self.inner.options.max_derived_facts,
+                self.inner.options.max_results,
+            );
+            return executor.execute(cmd);
+        }
+
+        let merged_facts = self.merged_query_facts()?;
+        let mut executor = DatalogExecutor::new_from_facts_with_rules_and_functions(
+            merged_facts,
+            self.inner.rules.clone(),
+            self.inner.functions.clone(),
+        );
+        executor.set_limits(
+            self.inner.options.max_derived_facts,
+            self.inner.options.max_results,
+        );
+        executor.execute(cmd)
     }
 
     /// Commit this transaction atomically.
@@ -952,41 +975,24 @@ impl<'a> WriteTransaction<'a> {
         set_write_tx_active(false);
     }
 
-    /// Build a temporary `FactStorage` that merges committed facts with pending ones.
-    ///
-    /// Used to implement read-your-own-writes semantics during a transaction.
-    ///
-    /// This performs a **deep copy**: a brand-new `FactStorage` is created and
-    /// populated with all committed facts followed by the pending buffered facts.
-    /// Using `self.inner.fact_storage.clone()` would be an Arc-based shallow clone
-    /// that shares the underlying storage, causing `load_fact()` calls to mutate
-    /// the shared store and expose uncommitted facts to concurrent readers.
-    ///
-    /// Optimization: if there are no pending facts, we can use the storage directly
-    /// without copying. Otherwise, we create an overlay that combines committed
-    /// facts with pending facts without copying all committed facts.
-    fn build_query_view(&self) -> Result<FactStorage> {
-        // Fast path: no pending facts, use the original storage directly
-        if self.pending_facts.is_empty() {
-            return Ok(self.inner.fact_storage.clone());
-        }
+    /// Build a merged fact snapshot for transactional reads.
+    fn merged_query_facts(&self) -> Result<Arc<[Fact]>> {
+        let committed = self.inner.fact_storage.get_all_facts()?;
+        let mut merged = Vec::with_capacity(committed.len() + self.pending_facts.len());
+        merged.extend(committed);
 
-        // Slow path: need to combine committed + pending facts
-        // Create overlay that reads from both sources without full copy
-        let view = FactStorage::new();
+        let overlay_tx_id = crate::graph::types::tx_id_now();
+        let overlay_tx_count = self.inner.fact_storage.current_tx_count() + 1;
 
-        // Load committed facts - this is the expensive part
-        for fact in self.inner.fact_storage.get_all_facts()? {
-            view.load_fact(fact)?;
-        }
-
-        // Add pending facts
-        for fact in &self.pending_facts {
-            view.load_fact(fact.clone())?;
-        }
-
-        view.restore_tx_counter()?;
-        Ok(view)
+        merged.extend(self.pending_facts.iter().cloned().map(|mut fact| {
+            fact.tx_id = overlay_tx_id;
+            fact.tx_count = overlay_tx_count;
+            if fact.asserted && fact.valid_from == VALID_FROM_USE_TX_TIME {
+                fact.valid_from = overlay_tx_id as i64;
+            }
+            fact
+        }));
+        Ok(Arc::from(merged))
     }
 }
 
@@ -1127,6 +1133,30 @@ mod tests {
             QueryResult::QueryResults { results, .. } => {
                 assert_eq!(results.len(), 1, "should see only one visible age");
                 assert_eq!(results[0][0], Value::Integer(31));
+            }
+            _ => panic!("expected QueryResults"),
+        }
+    }
+
+    #[test]
+    fn test_write_transaction_rule_query_with_pending_write() {
+        let db = Minigraf::in_memory().unwrap();
+        db.execute("(rule [(reachable ?x ?y) [?x :edge ?y]])").unwrap();
+        db.execute("(rule [(reachable ?x ?y) [?x :edge ?z] (reachable ?z ?y)])")
+            .unwrap();
+        db.execute("(transact [[:a :edge :b]])").unwrap();
+
+        let mut tx = db.begin_write().unwrap();
+        tx.execute("(transact [[:b :edge :c]])").unwrap();
+
+        let result = tx.execute("(query [:find ?y :where (reachable :a ?y)])").unwrap();
+
+        match result {
+            QueryResult::QueryResults { results, .. } => {
+                assert!(
+                    results.iter().any(|row| row[0] == Value::Keyword(":c".to_string())),
+                    "rule query should see pending edge"
+                );
             }
             _ => panic!("expected QueryResults"),
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -870,6 +870,7 @@ impl<'a> WriteTransaction<'a> {
         let merged_facts = self.merged_query_facts()?;
         let mut executor = DatalogExecutor::new_from_facts_with_rules_and_functions(
             merged_facts,
+            self.pending_read_now_floor(),
             self.inner.rules.clone(),
             self.inner.functions.clone(),
         );
@@ -1021,6 +1022,14 @@ impl<'a> WriteTransaction<'a> {
         merged.extend(committed);
         merged.extend(self.pending_facts.iter().cloned());
         Ok(Arc::from(merged))
+    }
+
+    /// Return the read-time floor implied by pending facts only.
+    fn pending_read_now_floor(&self) -> Option<i64> {
+        self.pending_facts
+            .iter()
+            .map(|fact| fact.tx_id as i64)
+            .max()
     }
 }
 
@@ -1240,6 +1249,18 @@ mod tests {
 
         tx.execute(r#"(transact [[:alice :person/age 31]])"#).unwrap();
 
+        let future_tx_id = tx_id as u64 + 60_000;
+        let future_fact = Fact::with_valid_time(
+            uuid::Uuid::new_v4(),
+            ":future/marker".to_string(),
+            Value::Integer(99),
+            future_tx_id,
+            1,
+            future_tx_id as i64,
+            VALID_TIME_FOREVER,
+        );
+        db.inner.fact_storage.load_fact(future_fact).unwrap();
+
         let as_of_timestamp = chrono::DateTime::<Utc>::from_timestamp_millis(tx_id)
             .unwrap()
             .to_rfc3339_opts(SecondsFormat::Millis, true);
@@ -1253,6 +1274,20 @@ mod tests {
             QueryResult::QueryResults { results, .. } => {
                 assert_eq!(results.len(), 1);
                 assert_eq!(results[0][0], Value::Integer(30));
+            }
+            _ => panic!("expected QueryResults"),
+        }
+
+        let future_query = tx
+            .execute(r#"(query [:find ?v :where [?e :future/marker ?v]])"#)
+            .unwrap();
+        match future_query {
+            QueryResult::QueryResults { results, .. } => {
+                assert_eq!(
+                    results.len(),
+                    0,
+                    "future committed facts must not become visible from pending-only floor"
+                );
             }
             _ => panic!("expected QueryResults"),
         }

--- a/src/graph/storage.rs
+++ b/src/graph/storage.rs
@@ -288,25 +288,6 @@ impl FactStorage {
         self.tx_counter.fetch_add(1, Ordering::SeqCst) + 1
     }
 
-    /// Return all facts visible as of the given transaction point.
-    ///
-    /// * `AsOf::Counter(n)` — include facts whose `tx_count <= n`
-    /// * `AsOf::Timestamp(t)` — include facts whose `tx_id <= t as u64`
-    pub(crate) fn get_facts_as_of(&self, as_of: &AsOf) -> Result<Vec<Fact>> {
-        let all = self.get_all_facts()?;
-        let filtered = all
-            .into_iter()
-            .filter(|f| match as_of {
-                AsOf::Counter(n) => f.tx_count <= *n,
-                AsOf::Timestamp(t) => f.tx_id <= *t as u64,
-                AsOf::Slot(_) => {
-                    panic!("internal: unsubstituted :as-of bind slot reached get_facts_as_of");
-                }
-            })
-            .collect();
-        Ok(filtered)
-    }
-
     /// Get all facts (including retractions)
     ///
     /// Returns the complete append-only log. For current state, filter by
@@ -322,6 +303,15 @@ impl FactStorage {
         // Then pending facts (post-checkpoint, in memory)
         all.extend(d.facts.iter().cloned());
         Ok(all)
+    }
+
+    /// Return all facts visible as of the given transaction point.
+    ///
+    /// * `AsOf::Counter(n)` — include facts whose `tx_count <= n`
+    /// * `AsOf::Timestamp(t)` — include facts whose `tx_id <= t as u64`
+    pub(crate) fn get_facts_as_of(&self, as_of: &AsOf) -> Result<Vec<Fact>> {
+        let all = self.get_all_facts()?;
+        Ok(filter_facts_as_of(all, as_of))
     }
 
     /// Get all asserted facts (filters out retractions)
@@ -418,6 +408,22 @@ impl FactStorage {
             d.pending_indexes.vaet.len(),
         )
     }
+}
+
+/// Apply transaction-time snapshot semantics to a batch of facts.
+///
+/// Shared by `FactStorage::get_facts_as_of()` and transactional overlay reads.
+pub(crate) fn filter_facts_as_of(facts: Vec<Fact>, as_of: &AsOf) -> Vec<Fact> {
+    facts
+        .into_iter()
+        .filter(|f| match as_of {
+            AsOf::Counter(n) => f.tx_count <= *n,
+            AsOf::Timestamp(t) => f.tx_id <= *t as u64,
+            AsOf::Slot(_) => {
+                panic!("internal: unsubstituted :as-of bind slot reached get_facts_as_of");
+            }
+        })
+        .collect()
 }
 
 /// Compute the net-asserted view of a fact set.

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -73,6 +73,7 @@ pub enum QueryResult {
 /// Executor for Datalog commands
 pub struct DatalogExecutor {
     storage: FactStorage,
+    facts_override: Option<Arc<[Fact]>>,
     rules: Arc<RwLock<RuleRegistry>>,
     // RwLock pre-wired for 7.7b register_aggregate API.
     functions: Arc<RwLock<FunctionRegistry>>,
@@ -87,6 +88,7 @@ impl DatalogExecutor {
         let indexes = storage.pending_indexes_snapshot();
         DatalogExecutor {
             storage,
+            facts_override: None,
             rules: Arc::new(RwLock::new(RuleRegistry::new())),
             functions: Arc::new(RwLock::new(FunctionRegistry::with_builtins())),
             indexes: Arc::new(indexes),
@@ -106,6 +108,35 @@ impl DatalogExecutor {
         let indexes = storage.pending_indexes_snapshot();
         DatalogExecutor {
             storage,
+            facts_override: None,
+            rules,
+            functions,
+            indexes: Arc::new(indexes),
+            max_derived_facts: crate::query::datalog::evaluator::DEFAULT_MAX_DERIVED_FACTS,
+            max_results: crate::query::datalog::evaluator::DEFAULT_MAX_RESULTS,
+        }
+    }
+
+    /// Create a `DatalogExecutor` over a merged fact slice while sharing rules and functions.
+    pub fn new_from_facts_with_rules_and_functions(
+        facts: Arc<[Fact]>,
+        rules: Arc<RwLock<RuleRegistry>>,
+        functions: Arc<RwLock<FunctionRegistry>>,
+    ) -> Self {
+        let mut indexes = crate::storage::index::Indexes::new();
+        for (slot_index, fact) in facts.iter().enumerate() {
+            indexes.insert(
+                fact,
+                crate::storage::index::FactRef {
+                    page_id: 0,
+                    slot_index: slot_index as u16,
+                },
+            );
+        }
+
+        DatalogExecutor {
+            storage: FactStorage::new(),
+            facts_override: Some(facts),
             rules,
             functions,
             indexes: Arc::new(indexes),
@@ -140,6 +171,7 @@ impl DatalogExecutor {
         let indexes = storage.pending_indexes_snapshot();
         DatalogExecutor {
             storage,
+            facts_override: None,
             rules,
             functions,
             indexes: Arc::new(indexes),
@@ -255,10 +287,25 @@ impl DatalogExecutor {
     fn filter_facts_for_query(&self, query: &DatalogQuery) -> Result<Arc<[Fact]>> {
         let now = tx_id_now() as i64;
 
+        let source_facts: Vec<Fact> = match &self.facts_override {
+            Some(facts) => facts.iter().cloned().collect(),
+            None => match &query.as_of {
+                Some(as_of) => self.storage.get_facts_as_of(as_of)?,
+                None => self.storage.get_all_facts()?,
+            },
+        };
+
         // Step 1: transaction-time filter
         let tx_filtered: Vec<Fact> = match &query.as_of {
-            Some(as_of) => self.storage.get_facts_as_of(as_of)?,
-            None => self.storage.get_all_facts()?,
+            Some(as_of) => source_facts
+                .into_iter()
+                .filter(|fact| match as_of {
+                    AsOf::Counter(counter) => fact.tx_count <= *counter,
+                    AsOf::Timestamp(ts) => fact.tx_id as i64 <= *ts,
+                    AsOf::Slot(_) => false,
+                })
+                .collect(),
+            None => source_facts,
         };
 
         // Step 2: compute net-asserted view — for each (entity, attribute, value) triple,

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -74,6 +74,7 @@ pub enum QueryResult {
 pub struct DatalogExecutor {
     storage: FactStorage,
     facts_override: Option<Arc<[Fact]>>,
+    read_now_floor: Option<i64>,
     rules: Arc<RwLock<RuleRegistry>>,
     // RwLock pre-wired for 7.7b register_aggregate API.
     functions: Arc<RwLock<FunctionRegistry>>,
@@ -89,6 +90,7 @@ impl DatalogExecutor {
         DatalogExecutor {
             storage,
             facts_override: None,
+            read_now_floor: None,
             rules: Arc::new(RwLock::new(RuleRegistry::new())),
             functions: Arc::new(RwLock::new(FunctionRegistry::with_builtins())),
             indexes: Arc::new(indexes),
@@ -109,6 +111,7 @@ impl DatalogExecutor {
         DatalogExecutor {
             storage,
             facts_override: None,
+            read_now_floor: None,
             rules,
             functions,
             indexes: Arc::new(indexes),
@@ -120,12 +123,14 @@ impl DatalogExecutor {
     /// Create a `DatalogExecutor` over a merged fact slice while sharing rules and functions.
     pub(crate) fn new_from_facts_with_rules_and_functions(
         facts: Arc<[Fact]>,
+        pending_read_now_floor: Option<i64>,
         rules: Arc<RwLock<RuleRegistry>>,
         functions: Arc<RwLock<FunctionRegistry>>,
     ) -> Self {
         DatalogExecutor {
             storage: FactStorage::new(),
             facts_override: Some(facts),
+            read_now_floor: pending_read_now_floor,
             rules,
             functions,
             indexes: Arc::new(crate::storage::index::Indexes::new()),
@@ -161,6 +166,7 @@ impl DatalogExecutor {
         DatalogExecutor {
             storage,
             facts_override: None,
+            read_now_floor: None,
             rules,
             functions,
             indexes: Arc::new(indexes),
@@ -182,14 +188,7 @@ impl DatalogExecutor {
     /// of the current millisecond.
     fn read_now(&self) -> i64 {
         let now = tx_id_now() as i64;
-        match &self.facts_override {
-            Some(facts) => facts
-                .iter()
-                .map(|fact| fact.tx_id as i64)
-                .max()
-                .map_or(now, |pending_now| now.max(pending_now)),
-            None => now,
-        }
+        self.read_now_floor.map_or(now, |floor| now.max(floor))
     }
 
     /// Execute a Datalog command

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -32,23 +32,6 @@ fn query_uses_per_fact_pseudo_attr(query: &DatalogQuery) -> bool {
     check_clauses(&query.where_clauses)
 }
 
-fn apply_as_of_filter(facts: Vec<Fact>, as_of: Option<&AsOf>) -> Result<Vec<Fact>> {
-    match as_of {
-        Some(AsOf::Counter(counter)) => Ok(facts
-            .into_iter()
-            .filter(|fact| fact.tx_count <= *counter)
-            .collect()),
-        Some(AsOf::Timestamp(ts)) => Ok(facts
-            .into_iter()
-            .filter(|fact| fact.tx_id as i64 <= *ts)
-            .collect()),
-        Some(AsOf::Slot(_)) => {
-            panic!("internal: unsubstituted :as-of bind slot reached the executor");
-        }
-        None => Ok(facts),
-    }
-}
-
 /// The result of executing a Datalog command via [`crate::db::Minigraf::execute`].
 ///
 /// Pattern-match on this to distinguish query results from write confirmations:
@@ -192,6 +175,23 @@ impl DatalogExecutor {
         self.max_results = max_results;
     }
 
+    /// Read-time "now" for query visibility.
+    ///
+    /// Overlay reads floor the wall clock to the newest staged fact so buffered
+    /// writes remain visible even if their synthetic metadata is slightly ahead
+    /// of the current millisecond.
+    fn read_now(&self) -> i64 {
+        let now = tx_id_now() as i64;
+        match &self.facts_override {
+            Some(facts) => facts
+                .iter()
+                .map(|fact| fact.tx_id as i64)
+                .max()
+                .map_or(now, |pending_now| now.max(pending_now)),
+            None => now,
+        }
+    }
+
     /// Execute a Datalog command
     pub fn execute(&self, command: DatalogCommand) -> Result<QueryResult> {
         match command {
@@ -291,21 +291,18 @@ impl DatalogExecutor {
     /// selective attribute/entity lookups instead of the full `get_all_facts()` scan (step 1).
     /// Also investigate caching the `net_asserted_facts()` result and invalidating on write (step 2).
     fn filter_facts_for_query(&self, query: &DatalogQuery) -> Result<Arc<[Fact]>> {
-        let now = tx_id_now() as i64;
+        let now = self.read_now();
 
-        let source_facts: Vec<Fact> = match &self.facts_override {
-            Some(facts) => facts.iter().cloned().collect(),
-            None => match &query.as_of {
-                Some(as_of) => self.storage.get_facts_as_of(as_of)?,
-                None => self.storage.get_all_facts()?,
-            },
+        let source_facts: Vec<Fact> = match (&self.facts_override, query.as_of.as_ref()) {
+            (Some(facts), Some(as_of)) => {
+                crate::graph::storage::filter_facts_as_of(facts.iter().cloned().collect(), as_of)
+            }
+            (Some(facts), None) => facts.iter().cloned().collect(),
+            (None, Some(as_of)) => self.storage.get_facts_as_of(as_of)?,
+            (None, None) => self.storage.get_all_facts()?,
         };
 
-        let tx_filtered = if self.facts_override.is_some() {
-            apply_as_of_filter(source_facts, query.as_of.as_ref())?
-        } else {
-            source_facts
-        };
+        let tx_filtered = source_facts;
 
         // Step 2: compute net-asserted view — for each (entity, attribute, value) triple,
         // keep it only if the record with the highest tx_count is an assertion.
@@ -348,7 +345,7 @@ impl DatalogExecutor {
         }
 
         // Compute query-level valid_at value for :db/valid-at pseudo-attribute binding.
-        let now = tx_id_now() as i64;
+        let now = self.read_now();
         let valid_at_value = match &query.valid_at {
             Some(ValidAt::Timestamp(t)) => Value::Integer(*t),
             Some(ValidAt::AnyValidTime) => Value::Null,
@@ -477,7 +474,7 @@ impl DatalogExecutor {
             .collect();
 
         // Compute query-level valid_at value for :db/valid-at pseudo-attribute binding.
-        let now = tx_id_now() as i64;
+        let now = self.read_now();
         let valid_at_value = match &query.valid_at {
             Some(ValidAt::Timestamp(t)) => Value::Integer(*t),
             Some(ValidAt::AnyValidTime) => Value::Null,

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -32,6 +32,23 @@ fn query_uses_per_fact_pseudo_attr(query: &DatalogQuery) -> bool {
     check_clauses(&query.where_clauses)
 }
 
+fn apply_as_of_filter(facts: Vec<Fact>, as_of: Option<&AsOf>) -> Result<Vec<Fact>> {
+    match as_of {
+        Some(AsOf::Counter(counter)) => Ok(facts
+            .into_iter()
+            .filter(|fact| fact.tx_count <= *counter)
+            .collect()),
+        Some(AsOf::Timestamp(ts)) => Ok(facts
+            .into_iter()
+            .filter(|fact| fact.tx_id as i64 <= *ts)
+            .collect()),
+        Some(AsOf::Slot(_)) => {
+            panic!("internal: unsubstituted :as-of bind slot reached the executor");
+        }
+        None => Ok(facts),
+    }
+}
+
 /// The result of executing a Datalog command via [`crate::db::Minigraf::execute`].
 ///
 /// Pattern-match on this to distinguish query results from write confirmations:
@@ -284,17 +301,10 @@ impl DatalogExecutor {
             },
         };
 
-        // Step 1: transaction-time filter
-        let tx_filtered: Vec<Fact> = match &query.as_of {
-            Some(as_of) => source_facts
-                .into_iter()
-                .filter(|fact| match as_of {
-                    AsOf::Counter(counter) => fact.tx_count <= *counter,
-                    AsOf::Timestamp(ts) => fact.tx_id as i64 <= *ts,
-                    AsOf::Slot(_) => false,
-                })
-                .collect(),
-            None => source_facts,
+        let tx_filtered = if self.facts_override.is_some() {
+            apply_as_of_filter(source_facts, query.as_of.as_ref())?
+        } else {
+            source_facts
         };
 
         // Step 2: compute net-asserted view — for each (entity, attribute, value) triple,

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -118,7 +118,7 @@ impl DatalogExecutor {
     }
 
     /// Create a `DatalogExecutor` over a merged fact slice while sharing rules and functions.
-    pub fn new_from_facts_with_rules_and_functions(
+    pub(crate) fn new_from_facts_with_rules_and_functions(
         facts: Arc<[Fact]>,
         rules: Arc<RwLock<RuleRegistry>>,
         functions: Arc<RwLock<FunctionRegistry>>,

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -123,23 +123,12 @@ impl DatalogExecutor {
         rules: Arc<RwLock<RuleRegistry>>,
         functions: Arc<RwLock<FunctionRegistry>>,
     ) -> Self {
-        let mut indexes = crate::storage::index::Indexes::new();
-        for (slot_index, fact) in facts.iter().enumerate() {
-            indexes.insert(
-                fact,
-                crate::storage::index::FactRef {
-                    page_id: 0,
-                    slot_index: slot_index as u16,
-                },
-            );
-        }
-
         DatalogExecutor {
             storage: FactStorage::new(),
             facts_override: Some(facts),
             rules,
             functions,
-            indexes: Arc::new(indexes),
+            indexes: Arc::new(crate::storage::index::Indexes::new()),
             max_derived_facts: crate::query::datalog::evaluator::DEFAULT_MAX_DERIVED_FACTS,
             max_results: crate::query::datalog::evaluator::DEFAULT_MAX_RESULTS,
         }


### PR DESCRIPTION
Closes #96

## Summary

- Removes the `build_query_view()` deep-copy path from `WriteTransaction`. Previously, every mid-transaction query with pending writes materialized a fresh `FactStorage` by loading all committed facts and rebuilding all indexes — O(N) in committed store size per query.
- **Fast path** (no pending facts): reuses the shared `FactStorage` `Arc` clone directly — zero copy.
- **Slow path** (pending facts present): collects committed facts into a `Vec`, appends pending facts, wraps in `Arc<[Fact]>` and passes to a new `DatalogExecutor::new_from_facts_with_rules_and_functions` constructor. No `FactStorage` reindex.
- Adds `stage_pending_facts()` to assign stable synthetic `tx_id`/`tx_count` to buffered facts at write time, keeping transactional read metadata coherent across multiple reads within the same transaction.
- Extracts `filter_facts_as_of()` as a free function in `storage.rs`, shared by both the committed and overlay read paths.
- Fixes a bug where `stage_pending_facts` was resolving the `VALID_FROM_USE_TX_TIME` sentinel prematurely, causing facts from later write batches in the same transaction to carry `valid_from` values slightly in the future — making them invisible to queries and lost after WAL recovery.

## Test plan

- [ ] `cargo test` — 529 tests, 0 failures (verified via pre-push hook)
- [ ] `test_write_transaction_read_your_own_writes` — pending facts visible in mid-transaction query
- [ ] `test_write_transaction_query_with_pending_retraction_and_assertion` — pending retract+assert overrides committed value
- [ ] `test_write_transaction_pending_retraction_only_hides_committed_fact` — committed fact retracted in-transaction disappears from query results
- [ ] `test_write_transaction_rule_query_with_pending_write` — recursive rules see pending edges
- [ ] `test_write_transaction_pending_metadata_is_stable_across_reads` — `tx_id`, `tx_count`, `valid_from` are stable across repeated reads within a transaction
- [ ] `test_explicit_tx_all_or_nothing_commit` (WAL) — multi-batch transactions survive crash + WAL recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)