### PR TITLE
perf(bench): trim largest scale from 5 timed-out CI jobs

### DIFF
--- a/benches/minigraf_bench.rs
+++ b/benches/minigraf_bench.rs
@@ -168,12 +168,7 @@ fn bench_insert_file(c: &mut Criterion) {
 // ── Task 5: query/ ────────────────────────────────────────────────────────────
 
 fn bench_query(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[
-        ("1k", 1_000),
-        ("10k", 10_000),
-        ("100k", 100_000),
-        ("1m", 1_000_000),
-    ];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
 
     // point_entity: EAVT range scan on a known entity
     {
@@ -723,7 +718,7 @@ fn bench_concurrent_file(c: &mut Criterion) {
 // ── Negation: not / not-join ──────────────────────────────────────────────────
 
 fn bench_negation(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // not/scale: overhead of the `not` post-filter at different DB sizes.
     // 10% of entities are excluded (`:banned true`).
@@ -876,7 +871,7 @@ fn bench_concurrent_btree_scan(c: &mut Criterion) {
 // ── Disjunction: or / or-join ─────────────────────────────────────────────────
 
 fn bench_disjunction(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // or/scale: overhead of the `or` expansion at different DB sizes.
     // 25% tagged-a (first quarter), 25% tagged-b (last quarter), 50% untagged.
@@ -976,7 +971,7 @@ fn bench_disjunction(c: &mut Criterion) {
 // ── Aggregation ───────────────────────────────────────────────────────────────
 
 fn bench_aggregation(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // count/scale: scalar `count` aggregate — measures aggregation post-processing overhead.
     // Single output row regardless of DB size; cost is dominated by binding collection.
@@ -1228,8 +1223,8 @@ fn bench_temporal_metadata(c: &mut Criterion) {
 
 fn bench_udf(c: &mut Criterion) {
     // Scalar-output UDF: safe to push to 100k.
-    const SCALES_SCALAR: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
-    const SCALES_LINEAR: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES_SCALAR: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
+    const SCALES_LINEAR: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // aggregate_sum_dispatch: UDF aggregate vs built-in sum — isolates closure dispatch.
     {
@@ -1286,7 +1281,7 @@ fn bench_udf(c: &mut Criterion) {
 // ── Aggregation: count-distinct ───────────────────────────────────────────────
 
 fn bench_aggregation_extras(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // count_distinct_scale: count-distinct with 50% duplicate values.
     // Measures the distinct-dedup path overhead.

--- a/src/graph/storage.rs
+++ b/src/graph/storage.rs
@@ -147,8 +147,7 @@ impl FactStorage {
             .collect();
 
         let mut d = self.data.write().unwrap();
-        let mut slot = d.facts.len() as u16;
-        for fact in &facts {
+        for (slot, fact) in (d.facts.len() as u16..).zip(facts.iter()) {
             d.pending_keys.insert(pending_key(fact));
             d.pending_indexes.insert(
                 fact,
@@ -157,7 +156,6 @@ impl FactStorage {
                     slot_index: slot,
                 },
             );
-            slot += 1;
         }
         d.facts.extend(facts);
 
@@ -199,8 +197,7 @@ impl FactStorage {
             .collect();
 
         let mut d = self.data.write().unwrap();
-        let mut slot = d.facts.len() as u16;
-        for fact in &facts {
+        for (slot, fact) in (d.facts.len() as u16..).zip(facts.iter()) {
             d.pending_keys.insert(pending_key(fact));
             d.pending_indexes.insert(
                 fact,
@@ -209,7 +206,6 @@ impl FactStorage {
                     slot_index: slot,
                 },
             );
-            slot += 1;
         }
         d.facts.extend(facts);
 
@@ -240,8 +236,7 @@ impl FactStorage {
             .collect();
 
         let mut d = self.data.write().unwrap();
-        let mut slot = d.facts.len() as u16;
-        for fact in &retractions {
+        for (slot, fact) in (d.facts.len() as u16..).zip(retractions.iter()) {
             d.pending_keys.insert(pending_key(fact));
             d.pending_indexes.insert(
                 fact,
@@ -250,7 +245,6 @@ impl FactStorage {
                     slot_index: slot,
                 },
             );
-            slot += 1;
         }
         d.facts.extend(retractions);
 

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -1079,15 +1079,13 @@ fn apply_window_functions(
                     let mut values = Vec::with_capacity(row_indices.len());
                     let mut rank = 1i64;
                     let mut prev_order_val: Option<Value> = None;
-                    let mut row_num = 1i64;
-                    for &row_idx in row_indices.iter() {
+                    for (row_num, &row_idx) in (1i64..).zip(row_indices.iter()) {
                         let cur_val = bindings[row_idx].get(&ws.order_by).cloned();
                         if prev_order_val.as_ref() != cur_val.as_ref() {
                             rank = row_num;
                             prev_order_val = cur_val;
                         }
                         values.push(Value::Integer(rank));
-                        row_num += 1;
                     }
                     values
                 }
@@ -1137,7 +1135,7 @@ fn apply_window_functions(
             };
 
             // Write window values back to rows.
-            for (&row_idx, window_val) in row_indices.iter().zip(window_values.into_iter()) {
+            for (&row_idx, window_val) in row_indices.iter().zip(window_values) {
                 bindings[row_idx].insert(key.clone(), window_val);
             }
         }


### PR DESCRIPTION
## Summary

Five jobs cancelled in run [24499890234](https://github.com/adityamukho/minigraf/actions/runs/24499890234). Removed the largest pre-load scale from each:

| Job | Scale removed | Now tops out at |
|-----|--------------|-----------------|
| `query` | `1m` | `100k` |
| `negation` | `100k` | `10k` |
| `disjunction` | `100k` | `10k` |
| `udf` | `100k` | `10k` |
| `aggregation` | `100k` | `10k` |

All other benchmark groups are unchanged.

## Test plan

- [ ] All 5 previously-cancelled CI jobs complete within the 360-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)