### PR TITLE
perf(bench): drop 100k from bench/query (timed out)

### DIFF
--- a/benches/minigraf_bench.rs
+++ b/benches/minigraf_bench.rs
@@ -168,7 +168,7 @@ fn bench_insert_file(c: &mut Criterion) {
 // ── Task 5: query/ ────────────────────────────────────────────────────────────
 
 fn bench_query(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // point_entity: EAVT range scan on a known entity
     {
@@ -1304,7 +1304,7 @@ fn bench_aggregation_extras(c: &mut Criterion) {
 // ── Query: regex filter ──────────────────────────────────────────────────────
 
 fn bench_query_extras(c: &mut Criterion) {
-    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000), ("100k", 100_000)];
+    const SCALES: &[(&str, usize)] = &[("1k", 1_000), ("10k", 10_000)];
 
     // regex_filter: query with matches? predicate — measures regex evaluation overhead.
     // All entities have :val strings matching pattern "item-\d+".


### PR DESCRIPTION
## Summary

`bench / query` timed out again in run [24520755743](https://github.com/adityamukho/minigraf/actions/runs/24520755743) after being dropped from 1m → 100k in #127. Dropping to 10k max:

- `bench_query` (point_entity, point_attribute, join_3pattern): 1k, 10k ~~100k~~
- `bench_query_extras` (regex_filter): 1k, 10k ~~100k~~

## Test plan

- [ ] `bench / query` completes within the 360-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)