### PR TITLE
perf: Use HashMap for O(1) partition lookup in apply_window_functions

### DIFF
--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -70,6 +70,31 @@ pub enum Value {
 
 impl Eq for Value {}
 
+impl std::hash::Hash for Value {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Value::String(s) => s.hash(state),
+            Value::Integer(i) => i.hash(state),
+            Value::Float(f) => {
+                if f.is_nan() {
+                    0_u8.hash(state);
+                } else if f.is_sign_negative() {
+                    1_u8.hash(state);
+                    (-f).to_bits().hash(state);
+                } else {
+                    2_u8.hash(state);
+                    f.to_bits().hash(state);
+                }
+            }
+            Value::Boolean(b) => b.hash(state),
+            Value::Ref(r) => r.hash(state),
+            Value::Keyword(k) => k.hash(state),
+            Value::Null => {}
+        }
+    }
+}
+
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -10,6 +10,7 @@ use super::types::{
 use crate::graph::FactStorage;
 use crate::graph::types::{Fact, TransactOptions, TxId, Value, tx_id_now};
 use anyhow::{Result, anyhow};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 /// Returns true if any where clause (at any depth) contains a per-fact
@@ -1030,22 +1031,18 @@ fn apply_window_functions(
         let key = format!("__win_{}", i);
 
         // Build partitions: (partition_key, sorted row indices).
-        let mut partitions: Vec<(Option<Value>, Vec<usize>)> = Vec::new();
+        let mut partitions: HashMap<Option<Value>, Vec<usize>> = HashMap::new();
         for (row_idx, binding) in bindings.iter().enumerate() {
             let part_key = ws
                 .partition_by
                 .as_ref()
                 .and_then(|pv| binding.get(pv))
                 .cloned();
-            if let Some(pos) = partitions.iter().position(|(k, _)| k == &part_key) {
-                partitions[pos].1.push(row_idx);
-            } else {
-                partitions.push((part_key, vec![row_idx]));
-            }
+            partitions.entry(part_key).or_default().push(row_idx);
         }
 
         // For each partition: sort, compute window values, write back.
-        for (_, row_indices) in &mut partitions {
+        for row_indices in partitions.values_mut() {
             // Pre-extract order_by values into a contiguous Vec so the sort
             // comparator never touches the HashMap — O(n) lookups here instead
             // of O(n log n) random HashMap accesses inside sort_by.


### PR DESCRIPTION
## Summary
- Replace O(n×p) Vec linear scan with O(1) HashMap lookup in `apply_window_functions`
- Added manual `Hash` implementation for `Value` enum (f64 requires special handling for NaN)
- Clippy fixes: use `or_default()` instead of `or_insert_with`, iterate with `values_mut()`

Fixes #138