### PR TITLE
perf: Remove redundant sort in OrJoin branch dedup

### DIFF
--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -1368,9 +1368,7 @@ pub(crate) fn apply_or_clauses(
                         // (1) the parser enforces join_vars ⊆ outer_bound, so join_vars ⊆ outer_keys, and
                         // (2) retaining outer_keys is safe because those variables were stable before the or-join.
                         b.retain(|k, _| outer_keys.contains(k));
-                        let mut key: Vec<_> =
-                            b.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                        key.sort_unstable();
+                        let key: Vec<_> = b.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                         if seen.insert(key) {
                             result.push(b);
                         }


### PR DESCRIPTION
## Summary
- Remove redundant `sort_unstable()` call in OrJoin branch deduplication
- HashSet already uses equality for deduplication; ordering is not required
- Follows the same fix applied to `Or` clauses in PR #144

Fixes #140