### PR TITLE
feat(browser): add BrowserDb async WASM façade with IndexedDB persistence

### DIFF
--- a/.github/workflows/wasm-browser.yml
+++ b/.github/workflows/wasm-browser.yml
@@ -1,0 +1,71 @@
+name: WASM Browser
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build (release)
+        run: wasm-pack build --target web --features browser
+
+      - name: Check gzipped binary size
+        run: |
+          SIZE=$(gzip -c pkg/minigraf_bg.wasm | wc -c)
+          echo "Gzipped WASM size: ${SIZE} bytes"
+          if [ "$SIZE" -gt 1048576 ]; then
+            echo "WARNING: exceeds 1 MB gzipped budget (${SIZE} bytes)"
+          fi
+
+      - name: Upload pkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: pkg/
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup Chrome
+        if: matrix.browser == 'chrome'
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Setup Firefox
+        if: matrix.browser == 'firefox'
+        uses: browser-actions/setup-firefox@v1
+
+      - name: Test (headless ${{ matrix.browser }})
+        run: wasm-pack test --headless --${{ matrix.browser }} --features browser

--- a/.github/workflows/wasm-browser.yml
+++ b/.github/workflows/wasm-browser.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Build (release)
         run: wasm-pack build --target web --features browser
 
+      - name: Optimise with standalone wasm-opt
+        run: |
+          sudo apt-get install -y binaryen
+          wasm-opt --enable-bulk-memory -O -o pkg/minigraf_bg.wasm pkg/minigraf_bg.wasm
+
       - name: Check gzipped binary size
         run: |
           SIZE=$(gzip -c pkg/minigraf_bg.wasm | wc -c)

--- a/.github/workflows/wasm-browser.yml
+++ b/.github/workflows/wasm-browser.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Build (release)
         run: wasm-pack build --target web --features browser
 
-      - name: Optimise with standalone wasm-opt
-        run: |
-          sudo apt-get install -y binaryen
-          wasm-opt --enable-bulk-memory -O -o pkg/minigraf_bg.wasm pkg/minigraf_bg.wasm
-
       - name: Check gzipped binary size
         run: |
           SIZE=$(gzip -c pkg/minigraf_bg.wasm | wc -c)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["database-implementations", "embedded"]
 readme = "README.md"
 documentation = "https://docs.rs/minigraf"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ documentation = "https://docs.rs/minigraf"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/minigraf"
 crate-type = ["cdylib", "rlib"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory"]
+wasm-opt = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,14 @@ web-sys              = { version = "0.3", optional = true, features = [
 ] }
 
 [dev-dependencies]
-tempfile = "3"
 serde_json = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [[bench]]
 name = "minigraf_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,13 @@ regex-lite = "0.1.9"
 serde_json = { version = "1.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid                 = { version = "1.0", features = ["v4", "v5", "serde", "js"] }
 wasm-bindgen         = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 js-sys               = { version = "0.3", optional = true }
 web-sys              = { version = "0.3", optional = true, features = [
+    "DomStringList",
+    "Event",
     "IdbDatabase",
     "IdbFactory",
     "IdbIndex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,23 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde", "std"], default-features = false }
 uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 regex-lite = "0.1.9"
+serde_json = { version = "1.0", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen         = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+js-sys               = { version = "0.3", optional = true }
+web-sys              = { version = "0.3", optional = true, features = [
+    "IdbDatabase",
+    "IdbFactory",
+    "IdbIndex",
+    "IdbObjectStore",
+    "IdbOpenDbRequest",
+    "IdbRequest",
+    "IdbTransaction",
+    "IdbTransactionMode",
+    "Window",
+] }
 
 [dev-dependencies]
 tempfile = "3"
@@ -36,6 +53,13 @@ harness = false
 [features]
 default = []
 wasm = []
+browser = [
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+    "dep:js-sys",
+    "dep:serde_json",
+]
 
 [profile.release]
 panic = "abort"

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -1,0 +1,38 @@
+# Minigraf Browser Demo
+
+Demonstrates `@minigraf/core` running in a plain browser page with no bundler.
+
+## Build
+
+From the repo root:
+
+```bash
+wasm-pack build --target web --features browser
+```
+
+This produces `pkg/` containing `minigraf.js`, `minigraf_bg.wasm`, and
+`minigraf.d.ts`.
+
+## Serve
+
+```bash
+# From the repo root (not the examples/browser/ directory):
+python3 -m http.server 8080
+```
+
+Open `http://localhost:8080/examples/browser/` in Chrome or Firefox.
+
+## What it does
+
+- Opens an IndexedDB-backed database named `"minigraf-demo"`.
+- Transacts facts about Alice and Bob.
+- Queries Alice's friends with Datalog.
+- Exports the `.graph` blob and imports it into a fresh in-memory database.
+- Logs all results to the browser console (open with F12).
+
+## Notes
+
+- Data persists across page reloads (stored in IndexedDB).
+- The `pkg/` directory is gitignored — rebuild after pulling changes.
+- This package (`@minigraf/core`) is **browser-only**. For Node.js, use
+  `@minigraf/node` (Phase 8.3).

--- a/examples/browser/app.js
+++ b/examples/browser/app.js
@@ -1,0 +1,47 @@
+// Minigraf browser demo — no bundler required.
+// Build first: wasm-pack build --target web --features browser
+// Then serve from repo root: python3 -m http.server 8080
+// Open: http://localhost:8080/examples/browser/
+
+import init, { BrowserDb } from "../../pkg/minigraf.js";
+
+async function main() {
+  // Initialise the WASM module (loads minigraf_bg.wasm).
+  await init();
+
+  // Open a database backed by IndexedDB (persists across page reloads).
+  const db = await BrowserDb.open("minigraf-demo");
+
+  // Assert some facts.
+  await db.execute(`(transact [
+    [:alice :person/name "Alice"]
+    [:alice :person/age  30]
+    [:alice :friend      :bob]
+    [:bob   :person/name "Bob"]
+  ])`);
+
+  // Query with Datalog.
+  const raw = await db.execute(`
+    (query [:find ?friend-name
+            :where [:alice :friend ?f]
+                   [?f :person/name ?friend-name]])
+  `);
+  const result = JSON.parse(raw);
+  console.log("Alice's friends:", result.results.map(row => row[0]));
+  // Expected: ["Bob"]
+
+  // Export to a portable .graph blob.
+  const blob = db.exportGraph();
+  console.log(".graph blob size:", blob.byteLength, "bytes");
+
+  // Import into a fresh in-memory db.
+  const db2 = BrowserDb.openInMemory();
+  await db2.importGraph(blob);
+  const raw2 = await db2.execute(
+    `(query [:find ?name :where [?e :person/name ?name]])`
+  );
+  console.log("After import, names:", JSON.parse(raw2).results.map(r => r[0]));
+  // Expected: ["Alice", "Bob"] (order may vary)
+}
+
+main().catch(console.error);

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Minigraf Browser Demo</title>
+</head>
+<body>
+  <h1>Minigraf Browser Demo</h1>
+  <p>Open the browser console (F12) to see query results.</p>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/examples/memory_profile.rs
+++ b/examples/memory_profile.rs
@@ -5,9 +5,13 @@
 //! Inserts <fact_count> `:eN :val N` facts into a checkpointed file-backed DB,
 //! then runs a single point-entity query. Run under heaptrack to capture
 //! peak heap and allocation counts.
+//!
+//! Not applicable on WASM targets (no filesystem, no heaptrack).
 
+#[cfg(not(target_arch = "wasm32"))]
 use minigraf::OpenOptions;
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() -> anyhow::Result<()> {
     let n: usize = std::env::args()
         .nth(1)
@@ -46,3 +50,6 @@ fn main() -> anyhow::Result<()> {
     eprintln!("memory_profile: inserted and queried {} facts", n);
     Ok(())
 }
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/src/browser/buffer.rs
+++ b/src/browser/buffer.rs
@@ -55,6 +55,11 @@ impl BrowserBufferBackend {
     pub fn read_page_raw(&self, page_id: u64) -> anyhow::Result<Vec<u8>> {
         self.read_page(page_id)
     }
+
+    /// Return the number of pages stored (delegates to `StorageBackend::page_count`, usable without the trait).
+    pub fn page_count_raw(&self) -> anyhow::Result<u64> {
+        self.page_count()
+    }
 }
 
 impl StorageBackend for BrowserBufferBackend {

--- a/src/browser/buffer.rs
+++ b/src/browser/buffer.rs
@@ -50,6 +50,13 @@ impl Default for BrowserBufferBackend {
     }
 }
 
+impl BrowserBufferBackend {
+    /// Read a page by ID (delegates to `StorageBackend::read_page`, usable without the trait).
+    pub fn read_page_raw(&self, page_id: u64) -> anyhow::Result<Vec<u8>> {
+        self.read_page(page_id)
+    }
+}
+
 impl StorageBackend for BrowserBufferBackend {
     fn write_page(&mut self, page_id: u64, data: &[u8]) -> Result<()> {
         if data.len() != PAGE_SIZE {

--- a/src/browser/buffer.rs
+++ b/src/browser/buffer.rs
@@ -1,0 +1,175 @@
+use crate::storage::{PAGE_SIZE, StorageBackend};
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+
+/// Synchronous in-memory page buffer with dirty-page tracking.
+///
+/// Implements `StorageBackend` so it can be used with `PersistentFactStorage`.
+/// After `PersistentFactStorage::save()` writes updated pages here, call
+/// `take_dirty()` to retrieve the page IDs that must be flushed to IndexedDB.
+pub struct BrowserBufferBackend {
+    pages: HashMap<u64, Vec<u8>>,
+    dirty: HashSet<u64>,
+}
+
+impl BrowserBufferBackend {
+    /// Create an empty buffer (new database).
+    pub fn new() -> Self {
+        Self {
+            pages: HashMap::new(),
+            dirty: HashSet::new(),
+        }
+    }
+
+    /// Load pages from an existing snapshot. Dirty set starts empty.
+    /// Used during `BrowserDb::open()` after fetching all pages from IndexedDB.
+    pub fn load_pages(pages: HashMap<u64, Vec<u8>>) -> Self {
+        Self {
+            pages,
+            dirty: HashSet::new(),
+        }
+    }
+
+    /// Load pages and mark every page dirty.
+    /// Used during `BrowserDb::import_graph()` so all pages are flushed to IDB.
+    pub fn load_pages_all_dirty(pages: HashMap<u64, Vec<u8>>) -> Self {
+        let dirty: HashSet<u64> = pages.keys().copied().collect();
+        Self { pages, dirty }
+    }
+
+    /// Drain and return the set of page IDs written since the last call.
+    /// Clears the dirty set. Call after `pfs.save()` to get pages to flush.
+    pub fn take_dirty(&mut self) -> HashSet<u64> {
+        std::mem::take(&mut self.dirty)
+    }
+}
+
+impl Default for BrowserBufferBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StorageBackend for BrowserBufferBackend {
+    fn write_page(&mut self, page_id: u64, data: &[u8]) -> Result<()> {
+        if data.len() != PAGE_SIZE {
+            anyhow::bail!(
+                "Invalid page size: {} bytes (expected {})",
+                data.len(),
+                PAGE_SIZE
+            );
+        }
+        self.pages.insert(page_id, data.to_vec());
+        self.dirty.insert(page_id);
+        Ok(())
+    }
+
+    fn read_page(&self, page_id: u64) -> Result<Vec<u8>> {
+        self.pages
+            .get(&page_id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Page {} not found", page_id))
+    }
+
+    fn sync(&mut self) -> Result<()> {
+        Ok(()) // no-op: durability handled by IndexedDbBackend
+    }
+
+    fn page_count(&self) -> Result<u64> {
+        Ok(self.pages.len() as u64)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        Ok(()) // no-op
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "browser-buffer"
+    }
+
+    fn is_new(&self) -> bool {
+        self.pages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page(byte: u8) -> Vec<u8> {
+        vec![byte; PAGE_SIZE]
+    }
+
+    #[test]
+    fn write_marks_dirty() {
+        let mut buf = BrowserBufferBackend::new();
+        buf.write_page(0, &page(1)).unwrap();
+        let dirty = buf.take_dirty();
+        assert!(dirty.contains(&0));
+    }
+
+    #[test]
+    fn take_dirty_clears_set() {
+        let mut buf = BrowserBufferBackend::new();
+        buf.write_page(0, &page(1)).unwrap();
+        let _ = buf.take_dirty();
+        assert!(buf.take_dirty().is_empty());
+    }
+
+    #[test]
+    fn read_after_write_returns_same_bytes() {
+        let mut buf = BrowserBufferBackend::new();
+        let p = page(42);
+        buf.write_page(3, &p).unwrap();
+        assert_eq!(buf.read_page(3).unwrap(), p);
+    }
+
+    #[test]
+    fn page_count_reflects_distinct_ids() {
+        let mut buf = BrowserBufferBackend::new();
+        buf.write_page(0, &page(0)).unwrap();
+        buf.write_page(1, &page(1)).unwrap();
+        buf.write_page(0, &page(2)).unwrap(); // overwrite
+        assert_eq!(buf.page_count().unwrap(), 2);
+    }
+
+    #[test]
+    fn load_pages_starts_with_no_dirty() {
+        let pages = HashMap::from([(0u64, page(0)), (1u64, page(1))]);
+        let mut buf = BrowserBufferBackend::load_pages(pages);
+        assert!(buf.take_dirty().is_empty());
+    }
+
+    #[test]
+    fn load_pages_all_dirty_marks_all() {
+        let pages = HashMap::from([(0u64, page(0)), (1u64, page(1))]);
+        let mut buf = BrowserBufferBackend::load_pages_all_dirty(pages);
+        let dirty = buf.take_dirty();
+        assert!(dirty.contains(&0));
+        assert!(dirty.contains(&1));
+    }
+
+    #[test]
+    fn is_new_true_when_empty() {
+        assert!(BrowserBufferBackend::new().is_new());
+    }
+
+    #[test]
+    fn is_new_false_after_write() {
+        let mut buf = BrowserBufferBackend::new();
+        buf.write_page(0, &page(0)).unwrap();
+        assert!(!buf.is_new());
+    }
+
+    #[test]
+    fn wrong_page_size_errors() {
+        let mut buf = BrowserBufferBackend::new();
+        assert!(buf.write_page(0, &[0u8; 100]).is_err());
+    }
+
+    #[test]
+    fn read_missing_page_errors() {
+        let buf = BrowserBufferBackend::new();
+        assert!(buf.read_page(99).is_err());
+    }
+}

--- a/src/browser/indexeddb.rs
+++ b/src/browser/indexeddb.rs
@@ -1,0 +1,148 @@
+//! Async IndexedDB backend for browser WASM.
+//!
+//! This is NOT a `StorageBackend` implementor — it is async-only.
+//! Called directly by `BrowserDb` after synchronous `PersistentFactStorage::save()`.
+
+use js_sys::{Array, Promise, Uint8Array};
+use std::collections::HashMap;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{IdbDatabase, IdbRequest, IdbTransaction, IdbTransactionMode};
+
+/// Converts an `IdbRequest` into a JS `Promise` that resolves with the request result.
+fn request_to_promise(request: &IdbRequest) -> Promise {
+    let req = request.clone();
+    Promise::new(&mut |resolve, reject| {
+        let req_ok = req.clone();
+        let on_success: Closure<dyn FnMut(web_sys::Event)> =
+            Closure::once(move |_: web_sys::Event| {
+                let result = req_ok.result().unwrap_or(JsValue::NULL);
+                resolve.call1(&JsValue::NULL, &result).ok();
+            });
+        let on_error: Closure<dyn FnMut(web_sys::Event)> =
+            Closure::once(move |_: web_sys::Event| {
+                reject
+                    .call1(&JsValue::NULL, &JsValue::from_str("IdbRequest failed"))
+                    .ok();
+            });
+        req.set_onsuccess(Some(on_success.as_ref().unchecked_ref()));
+        req.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        on_success.forget();
+        on_error.forget();
+    })
+}
+
+/// Converts an `IdbTransaction` completion into a JS `Promise`.
+#[allow(dead_code)]
+fn transaction_to_promise(tx: &IdbTransaction) -> Promise {
+    let tx = tx.clone();
+    Promise::new(&mut |resolve, reject| {
+        let on_complete: Closure<dyn FnMut(web_sys::Event)> =
+            Closure::once(move |_: web_sys::Event| {
+                resolve.call0(&JsValue::NULL).ok();
+            });
+        let on_error: Closure<dyn FnMut(web_sys::Event)> =
+            Closure::once(move |_: web_sys::Event| {
+                reject
+                    .call1(&JsValue::NULL, &JsValue::from_str("IdbTransaction failed"))
+                    .ok();
+            });
+        tx.set_oncomplete(Some(on_complete.as_ref().unchecked_ref()));
+        tx.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        on_complete.forget();
+        on_error.forget();
+    })
+}
+
+/// Async wrapper around a browser IndexedDB database.
+///
+/// Object store schema:
+///   name:  `<db_name>`
+///   key:   page_id (u64 stored as JS number — f64, safe up to 2^53)
+///   value: 4096-byte Uint8Array
+pub struct IndexedDbBackend {
+    pub(crate) db: IdbDatabase,
+    pub(crate) store_name: String,
+}
+
+impl IndexedDbBackend {
+    /// Open (or create) an IndexedDB database with a single object store.
+    ///
+    /// If the object store does not exist, it is created in `onupgradeneeded`.
+    /// `db_name` is used as both the database name and the object store name.
+    pub async fn open(db_name: &str) -> Result<Self, JsValue> {
+        let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window object"))?;
+        let idb_factory = window
+            .indexed_db()?
+            .ok_or_else(|| JsValue::from_str("IndexedDB not available"))?;
+
+        let store_name = db_name.to_string();
+        let store_name_upgrade = store_name.clone();
+
+        let open_request = idb_factory.open_with_u32(db_name, 1)?;
+
+        // Create the object store if this is a fresh database (version upgrade).
+        let on_upgrade: Closure<dyn FnMut(web_sys::Event)> =
+            Closure::once(move |event: web_sys::Event| {
+                let target = event.target().unwrap();
+                let request: web_sys::IdbOpenDbRequest = target.dyn_into().unwrap();
+                let db: IdbDatabase = request.result().unwrap().dyn_into().unwrap();
+                if !db
+                    .object_store_names()
+                    .contains(&store_name_upgrade)
+                {
+                    db.create_object_store(&store_name_upgrade).unwrap();
+                }
+            });
+        open_request.set_onupgradeneeded(Some(on_upgrade.as_ref().unchecked_ref()));
+        on_upgrade.forget();
+
+        // Wait for the open to succeed.
+        JsFuture::from(request_to_promise(open_request.as_ref())).await?;
+
+        let db: IdbDatabase = open_request.result()?.dyn_into()?;
+        Ok(Self { db, store_name })
+    }
+
+    /// Load all pages from IndexedDB into a `HashMap<page_id, bytes>`.
+    ///
+    /// Uses `getAllKeys()` + `getAll()` in a single read transaction, then zips
+    /// the two result arrays. Both calls share the same `IdbTransaction` to
+    /// guarantee consistency (no writes can interleave between them).
+    pub async fn load_all_pages(&self) -> Result<HashMap<u64, Vec<u8>>, JsValue> {
+        let tx = self
+            .db
+            .transaction_with_str_and_mode(&self.store_name, IdbTransactionMode::Readonly)?;
+        let store = tx.object_store(&self.store_name)?;
+
+        let keys_req = store.get_all_keys()?;
+        let keys_val = JsFuture::from(request_to_promise(keys_req.as_ref())).await?;
+        let keys_arr: Array = keys_val.dyn_into()?;
+
+        let vals_req = store.get_all()?;
+        let vals_val = JsFuture::from(request_to_promise(vals_req.as_ref())).await?;
+        let vals_arr: Array = vals_val.dyn_into()?;
+
+        let mut pages = HashMap::with_capacity(keys_arr.length() as usize);
+        for i in 0..keys_arr.length() {
+            let key = keys_arr.get(i);
+            let page_id = key
+                .as_f64()
+                .ok_or_else(|| JsValue::from_str("page_id is not a number"))? as u64;
+            let val = vals_arr.get(i);
+            let arr: Uint8Array = val.dyn_into()?;
+            pages.insert(page_id, arr.to_vec());
+        }
+        Ok(pages)
+    }
+
+    /// Clone the underlying IdbDatabase handle (cheap — it's a JS object reference).
+    pub fn clone_handle(&self) -> Self {
+        Self {
+            db: self.db.clone(),
+            store_name: self.store_name.clone(),
+        }
+    }
+}

--- a/src/browser/indexeddb.rs
+++ b/src/browser/indexeddb.rs
@@ -5,9 +5,9 @@
 
 use js_sys::{Array, Promise, Uint8Array};
 use std::collections::HashMap;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{IdbDatabase, IdbRequest, IdbTransaction, IdbTransactionMode};
 
@@ -88,10 +88,7 @@ impl IndexedDbBackend {
                 let target = event.target().unwrap();
                 let request: web_sys::IdbOpenDbRequest = target.dyn_into().unwrap();
                 let db: IdbDatabase = request.result().unwrap().dyn_into().unwrap();
-                if !db
-                    .object_store_names()
-                    .contains(&store_name_upgrade)
-                {
+                if !db.object_store_names().contains(&store_name_upgrade) {
                     db.create_object_store(&store_name_upgrade).unwrap();
                 }
             });
@@ -129,7 +126,8 @@ impl IndexedDbBackend {
             let key = keys_arr.get(i);
             let page_id = key
                 .as_f64()
-                .ok_or_else(|| JsValue::from_str("page_id is not a number"))? as u64;
+                .ok_or_else(|| JsValue::from_str("page_id is not a number"))?
+                as u64;
             let val = vals_arr.get(i);
             let arr: Uint8Array = val.dyn_into()?;
             pages.insert(page_id, arr.to_vec());

--- a/src/browser/indexeddb.rs
+++ b/src/browser/indexeddb.rs
@@ -35,7 +35,6 @@ fn request_to_promise(request: &IdbRequest) -> Promise {
 }
 
 /// Converts an `IdbTransaction` completion into a JS `Promise`.
-#[allow(dead_code)]
 fn transaction_to_promise(tx: &IdbTransaction) -> Promise {
     let tx = tx.clone();
     Promise::new(&mut |resolve, reject| {
@@ -144,5 +143,35 @@ impl IndexedDbBackend {
             db: self.db.clone(),
             store_name: self.store_name.clone(),
         }
+    }
+
+    /// Write a batch of pages to IndexedDB in a single `readwrite` transaction.
+    ///
+    /// All `put` operations are queued synchronously on the store, then we wait
+    /// for the transaction's `oncomplete` event. If any put fails, the transaction
+    /// is aborted and an error is returned.
+    ///
+    /// `pages` is a list of `(page_id, page_bytes)` pairs. Empty input is a no-op.
+    pub async fn write_pages(&self, pages: Vec<(u64, Vec<u8>)>) -> Result<(), JsValue> {
+        if pages.is_empty() {
+            return Ok(());
+        }
+        let tx = self
+            .db
+            .transaction_with_str_and_mode(&self.store_name, IdbTransactionMode::Readwrite)?;
+        let store = tx.object_store(&self.store_name)?;
+
+        for (page_id, data) in &pages {
+            let key = JsValue::from_f64(*page_id as f64);
+            let arr = Uint8Array::from(data.as_slice());
+            store.put_with_key(&arr, &key)?;
+        }
+
+        // Wait for the transaction to commit. The IDB transaction commits
+        // automatically once all put requests have been processed and no
+        // new requests are made. We wait here to ensure durability before
+        // returning to the caller.
+        JsFuture::from(transaction_to_promise(&tx)).await?;
+        Ok(())
     }
 }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -1,0 +1,1 @@
+pub mod buffer;

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -100,8 +100,7 @@ impl BrowserDb {
     /// - Rule: `{"ok": true}`
     #[wasm_bindgen(js_name = execute)]
     pub async fn execute(&self, datalog: String) -> Result<String, JsValue> {
-        let cmd = parse_datalog_command(&datalog)
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let cmd = parse_datalog_command(&datalog).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
         // Peek at the discriminant before consuming `cmd`.
         let is_read = matches!(cmd, DatalogCommand::Query(_) | DatalogCommand::Rule(_));
@@ -144,13 +143,17 @@ impl BrowserDb {
     pub async fn checkpoint(&self) -> Result<(), JsValue> {
         let (dirty_pages, has_idb) = {
             let mut inner = self.inner.borrow_mut();
-            inner.pfs.save()
+            inner
+                .pfs
+                .save()
                 .map_err(|e| JsValue::from_str(&e.to_string()))?;
             let dirty_ids = inner.pfs.with_backend_mut(|b| b.take_dirty());
             let pages: Vec<(u64, Vec<u8>)> = dirty_ids
                 .into_iter()
                 .filter_map(|id| {
-                    inner.pfs.with_backend(|b| b.read_page_raw(id).ok().map(|d| (id, d)))
+                    inner
+                        .pfs
+                        .with_backend(|b| b.read_page_raw(id).ok().map(|d| (id, d)))
                 })
                 .collect();
             (pages, inner.idb.is_some())
@@ -173,12 +176,16 @@ impl BrowserDb {
     #[wasm_bindgen(js_name = exportGraph)]
     pub fn export_graph(&self) -> Result<js_sys::Uint8Array, JsValue> {
         let inner = self.inner.borrow();
-        let page_count = inner.pfs.with_backend(|b| b.page_count_raw())
+        let page_count = inner
+            .pfs
+            .with_backend(|b| b.page_count_raw())
             .map_err(|e| JsValue::from_str(&e.to_string()))? as usize;
 
         let mut blob = Vec::with_capacity(page_count * crate::storage::PAGE_SIZE);
         for id in 0..page_count as u64 {
-            let page = inner.pfs.with_backend(|b| b.read_page_raw(id))
+            let page = inner
+                .pfs
+                .with_backend(|b| b.read_page_raw(id))
                 .map_err(|e| JsValue::from_str(&e.to_string()))?;
             blob.extend_from_slice(&page);
         }
@@ -194,7 +201,9 @@ impl BrowserDb {
     pub async fn import_graph(&self, data: js_sys::Uint8Array) -> Result<(), JsValue> {
         let bytes = data.to_vec();
         if bytes.len() % crate::storage::PAGE_SIZE != 0 {
-            return Err(JsValue::from_str("import data length is not a multiple of PAGE_SIZE"));
+            return Err(JsValue::from_str(
+                "import data length is not a multiple of PAGE_SIZE",
+            ));
         }
 
         let mut pages = std::collections::HashMap::new();
@@ -305,13 +314,7 @@ impl BrowserDb {
         if !dirty_pages.is_empty() {
             let has_idb = self.inner.borrow().idb.is_some();
             if has_idb {
-                let idb = self
-                    .inner
-                    .borrow()
-                    .idb
-                    .as_ref()
-                    .unwrap()
-                    .clone_handle();
+                let idb = self.inner.borrow().idb.as_ref().unwrap().clone_handle();
                 idb.write_pages(dirty_pages).await?;
             }
         }
@@ -403,7 +406,11 @@ mod tests {
 
         let blob = db.export_graph().expect("export");
         let bytes = blob.to_vec();
-        assert_eq!(&bytes[0..4], b"MGRF", "exported blob must start with MGRF magic");
+        assert_eq!(
+            &bytes[0..4],
+            b"MGRF",
+            "exported blob must start with MGRF magic"
+        );
 
         let db2 = BrowserDb::open_in_memory().expect("open2");
         db2.import_graph(blob).await.expect("import");

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -4,5 +4,7 @@
 //! feature enabled. It is **not** compatible with Node.js or any server-side
 //! runtime. For Node.js, use `@minigraf/node` (Phase 8.3).
 
+/// Synchronous in-memory page buffer with dirty-page tracking.
 pub mod buffer;
+/// Async IndexedDB backend for browser WASM persistence.
 pub mod indexeddb;

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -1,10 +1,98 @@
 //! Browser WASM support: `BrowserDb` async façade backed by IndexedDB.
 //!
 //! This module is only compiled for `wasm32-unknown-unknown` with the `browser`
-//! feature enabled. It is **not** compatible with Node.js or any server-side
-//! runtime. For Node.js, use `@minigraf/node` (Phase 8.3).
+//! feature enabled. It is **not** compatible with Node.js, Deno, Bun, or any
+//! server-side runtime. For server-side Node.js, use `@minigraf/node` (Phase 8.3).
 
 /// Synchronous in-memory page buffer with dirty-page tracking.
 pub mod buffer;
 /// Async IndexedDB backend for browser WASM persistence.
 pub mod indexeddb;
+
+use crate::browser::buffer::BrowserBufferBackend;
+use crate::browser::indexeddb::IndexedDbBackend;
+use crate::graph::FactStorage;
+use crate::query::datalog::executor::{DatalogExecutor, QueryResult};
+use crate::query::datalog::functions::FunctionRegistry;
+use crate::query::datalog::rules::RuleRegistry;
+use crate::storage::persistent_facts::PersistentFactStorage;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::{Arc, RwLock};
+use wasm_bindgen::prelude::*;
+
+// Suppress "unused import" warnings for types that are imported now for use in
+// later tasks (Task 8: execute(), Task 9: checkpoint / export / import).
+#[allow(unused_imports)]
+use crate::query::datalog::executor::QueryResult as _QueryResult;
+#[allow(unused_imports)]
+use crate::query::datalog::executor::DatalogExecutor as _DatalogExecutor;
+
+/// Internal state shared by all `BrowserDb` clones.
+struct BrowserDbInner {
+    fact_storage: FactStorage,
+    rules: Arc<RwLock<RuleRegistry>>,
+    functions: Arc<RwLock<FunctionRegistry>>,
+    pfs: PersistentFactStorage<BrowserBufferBackend>,
+    /// `None` for in-memory databases (no IDB backing).
+    idb: Option<IndexedDbBackend>,
+}
+
+/// Browser-only Minigraf database handle backed by IndexedDB.
+///
+/// All public methods return `Promise`s. Use `await` in JavaScript.
+///
+/// **Not compatible with Node.js.** Use `@minigraf/node` for server-side use.
+#[wasm_bindgen]
+pub struct BrowserDb {
+    inner: Rc<RefCell<BrowserDbInner>>,
+}
+
+#[wasm_bindgen]
+impl BrowserDb {
+    /// Open an in-memory database (no IndexedDB — for testing only).
+    ///
+    /// Data is lost when the page is closed. Use `BrowserDb.open()` for persistence.
+    #[wasm_bindgen(js_name = openInMemory)]
+    pub fn open_in_memory() -> Result<BrowserDb, JsValue> {
+        let buffer = BrowserBufferBackend::new();
+        let pfs = PersistentFactStorage::new(buffer, 256)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let fact_storage = pfs.storage().clone();
+
+        Ok(BrowserDb {
+            inner: Rc::new(RefCell::new(BrowserDbInner {
+                fact_storage,
+                rules: Arc::new(RwLock::new(RuleRegistry::new())),
+                functions: Arc::new(RwLock::new(FunctionRegistry::with_builtins())),
+                pfs,
+                idb: None,
+            })),
+        })
+    }
+
+    /// Open or create a database backed by IndexedDB.
+    ///
+    /// `db_name` is used as both the IndexedDB database name and object store name.
+    /// Called as `await BrowserDb.open("mydb")` — NOT `new BrowserDb()`.
+    #[wasm_bindgen(js_name = open)]
+    pub async fn open(db_name: &str) -> Result<BrowserDb, JsValue> {
+        let idb = IndexedDbBackend::open(db_name).await?;
+        let existing = idb.load_all_pages().await?;
+
+        let buffer = BrowserBufferBackend::load_pages(existing);
+        let pfs = PersistentFactStorage::new(buffer, 256)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let fact_storage = pfs.storage().clone();
+
+        Ok(BrowserDb {
+            inner: Rc::new(RefCell::new(BrowserDbInner {
+                fact_storage,
+                rules: Arc::new(RwLock::new(RuleRegistry::new())),
+                functions: Arc::new(RwLock::new(FunctionRegistry::with_builtins())),
+                pfs,
+                idb: Some(idb),
+            })),
+        })
+    }
+}

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -135,6 +135,103 @@ impl BrowserDb {
             DatalogCommand::Query(_) | DatalogCommand::Rule(_) => unreachable!(),
         }
     }
+
+    /// Flush all dirty pages to IndexedDB.
+    ///
+    /// Write-through means individual `execute()` calls already flush dirty pages,
+    /// so `checkpoint()` is only needed after `import_graph()` or explicit bulk ops.
+    /// No-op for in-memory databases.
+    pub async fn checkpoint(&self) -> Result<(), JsValue> {
+        let (dirty_pages, has_idb) = {
+            let mut inner = self.inner.borrow_mut();
+            inner.pfs.save()
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            let dirty_ids = inner.pfs.with_backend_mut(|b| b.take_dirty());
+            let pages: Vec<(u64, Vec<u8>)> = dirty_ids
+                .into_iter()
+                .filter_map(|id| {
+                    inner.pfs.with_backend(|b| b.read_page_raw(id).ok().map(|d| (id, d)))
+                })
+                .collect();
+            (pages, inner.idb.is_some())
+        };
+
+        if has_idb && !dirty_pages.is_empty() {
+            let idb = self.inner.borrow().idb.as_ref().unwrap().clone_handle();
+            idb.write_pages(dirty_pages).await?;
+        }
+        Ok(())
+    }
+
+    /// Serialise the current database to a portable `.graph` blob.
+    ///
+    /// The blob is byte-for-bit compatible with native `.graph` files opened by
+    /// `Minigraf::open()`. Pages are always in ascending `page_id` order.
+    ///
+    /// Call `checkpoint()` on native before importing a file here to ensure
+    /// no WAL entries are missing from the main file.
+    #[wasm_bindgen(js_name = exportGraph)]
+    pub fn export_graph(&self) -> Result<js_sys::Uint8Array, JsValue> {
+        let inner = self.inner.borrow();
+        let page_count = inner.pfs.with_backend(|b| b.page_count_raw())
+            .map_err(|e| JsValue::from_str(&e.to_string()))? as usize;
+
+        let mut blob = Vec::with_capacity(page_count * crate::storage::PAGE_SIZE);
+        for id in 0..page_count as u64 {
+            let page = inner.pfs.with_backend(|b| b.read_page_raw(id))
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            blob.extend_from_slice(&page);
+        }
+        Ok(js_sys::Uint8Array::from(blob.as_slice()))
+    }
+
+    /// Replace the current database with a `.graph` blob.
+    ///
+    /// The blob must be a checkpointed native `.graph` file (no pending WAL sidecar).
+    /// All existing data is overwritten. After import, the new data is immediately
+    /// queryable and all dirty pages are flushed to IndexedDB.
+    #[wasm_bindgen(js_name = importGraph)]
+    pub async fn import_graph(&self, data: js_sys::Uint8Array) -> Result<(), JsValue> {
+        let bytes = data.to_vec();
+        if bytes.len() % crate::storage::PAGE_SIZE != 0 {
+            return Err(JsValue::from_str("import data length is not a multiple of PAGE_SIZE"));
+        }
+
+        let mut pages = std::collections::HashMap::new();
+        for (i, chunk) in bytes.chunks(crate::storage::PAGE_SIZE).enumerate() {
+            pages.insert(i as u64, chunk.to_vec());
+        }
+
+        // ── Sync section ──────────────────────────────────────────────────────────
+        let (dirty_pages, has_idb) = {
+            let mut inner = self.inner.borrow_mut();
+            let buffer = BrowserBufferBackend::load_pages_all_dirty(pages);
+            let mut new_pfs = PersistentFactStorage::new(buffer, 256)
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            let new_fact_storage = new_pfs.storage().clone();
+
+            // Drain dirty set and collect owned page bytes before swapping inner.
+            let dirty_ids = new_pfs.with_backend_mut(|b| b.take_dirty());
+            let dirty_pages: Vec<(u64, Vec<u8>)> = dirty_ids
+                .into_iter()
+                .filter_map(|id| {
+                    new_pfs.with_backend(|b| b.read_page_raw(id).ok().map(|d| (id, d)))
+                })
+                .collect();
+
+            inner.pfs = new_pfs;
+            inner.fact_storage = new_fact_storage;
+
+            (dirty_pages, inner.idb.is_some())
+        };
+        // ── Borrow dropped ────────────────────────────────────────────────────────
+
+        if has_idb && !dirty_pages.is_empty() {
+            let idb = self.inner.borrow().idb.as_ref().unwrap().clone_handle();
+            idb.write_pages(dirty_pages).await?;
+        }
+        Ok(())
+    }
 }
 
 impl BrowserDb {

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -14,19 +14,14 @@ use crate::browser::indexeddb::IndexedDbBackend;
 use crate::graph::FactStorage;
 use crate::query::datalog::executor::{DatalogExecutor, QueryResult};
 use crate::query::datalog::functions::FunctionRegistry;
+use crate::query::datalog::parser::parse_datalog_command;
 use crate::query::datalog::rules::RuleRegistry;
+use crate::query::datalog::types::DatalogCommand;
 use crate::storage::persistent_facts::PersistentFactStorage;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 use wasm_bindgen::prelude::*;
-
-// Suppress "unused import" warnings for types that are imported now for use in
-// later tasks (Task 8: execute(), Task 9: checkpoint / export / import).
-#[allow(unused_imports)]
-use crate::query::datalog::executor::QueryResult as _QueryResult;
-#[allow(unused_imports)]
-use crate::query::datalog::executor::DatalogExecutor as _DatalogExecutor;
 
 /// Internal state shared by all `BrowserDb` clones.
 struct BrowserDbInner {
@@ -94,5 +89,171 @@ impl BrowserDb {
                 idb: Some(idb),
             })),
         })
+    }
+
+    /// Execute a Datalog command string and return a JSON-encoded result.
+    ///
+    /// Returns a `Promise<string>` in JavaScript. The JSON shape is:
+    /// - Query: `{"variables": [...], "results": [[...], ...]}`
+    /// - Transact: `{"transacted": <tx_id>}`
+    /// - Retract: `{"retracted": <tx_id>}`
+    /// - Rule: `{"ok": true}`
+    #[wasm_bindgen(js_name = execute)]
+    pub async fn execute(&self, datalog: String) -> Result<String, JsValue> {
+        let cmd = parse_datalog_command(&datalog)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        // Peek at the discriminant before consuming `cmd`.
+        let is_read = matches!(cmd, DatalogCommand::Query(_) | DatalogCommand::Rule(_));
+
+        if is_read {
+            let result = {
+                let inner = self.inner.borrow();
+                DatalogExecutor::new_with_rules_and_functions(
+                    inner.fact_storage.clone(),
+                    inner.rules.clone(),
+                    inner.functions.clone(),
+                )
+                .execute(cmd)
+                .map_err(|e| JsValue::from_str(&e.to_string()))?
+            };
+            return Ok(query_result_to_json(result));
+        }
+
+        match cmd {
+            DatalogCommand::Transact(tx) => {
+                let facts = crate::db::Minigraf::materialize_transaction(&tx)
+                    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+                self.apply_write(facts, false).await
+            }
+            DatalogCommand::Retract(tx) => {
+                let facts = crate::db::Minigraf::materialize_retraction(&tx)
+                    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+                self.apply_write(facts, true).await
+            }
+            // Handled above; unreachable but required for exhaustiveness.
+            DatalogCommand::Query(_) | DatalogCommand::Rule(_) => unreachable!(),
+        }
+    }
+}
+
+impl BrowserDb {
+    /// Apply a batch of pre-materialized facts to the in-memory store and
+    /// flush dirty pages to IndexedDB (if present).
+    ///
+    /// The `RefCell` borrow is fully released before the `.await` so that no
+    /// borrow is held across the async boundary.
+    async fn apply_write(
+        &self,
+        facts: Vec<crate::graph::types::Fact>,
+        is_retract: bool,
+    ) -> Result<String, JsValue> {
+        use crate::db::VALID_FROM_USE_TX_TIME;
+        use crate::graph::types::tx_id_now;
+
+        // ── Sync section: hold borrow, do ALL sync work, collect owned data ──
+        let (dirty_pages, result_json) = {
+            let mut inner = self.inner.borrow_mut();
+
+            let tx_count = inner.fact_storage.allocate_tx_count();
+            let tx_id = tx_id_now();
+
+            let stamped: Vec<crate::graph::types::Fact> = facts
+                .into_iter()
+                .map(|mut f| {
+                    f.tx_id = tx_id;
+                    f.tx_count = tx_count;
+                    if f.asserted && f.valid_from == VALID_FROM_USE_TX_TIME {
+                        f.valid_from = tx_id as i64;
+                    }
+                    f
+                })
+                .collect();
+
+            for fact in &stamped {
+                inner
+                    .fact_storage
+                    .load_fact(fact.clone())
+                    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            }
+
+            inner
+                .pfs
+                .save()
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+            // Collect dirty pages as owned Vec<(u64, Vec<u8>)> — no borrows escape
+            let dirty_ids = inner.pfs.with_backend_mut(|b| b.take_dirty());
+            let dirty_pages: Vec<(u64, Vec<u8>)> = dirty_ids
+                .into_iter()
+                .filter_map(|id| {
+                    inner
+                        .pfs
+                        .with_backend(|b| b.read_page_raw(id).ok().map(|d| (id, d)))
+                })
+                .collect();
+
+            let json = if is_retract {
+                format!(r#"{{"retracted":{}}}"#, tx_id)
+            } else {
+                format!(r#"{{"transacted":{}}}"#, tx_id)
+            };
+
+            (dirty_pages, json)
+        };
+        // ── Borrow dropped here ───────────────────────────────────────────────
+
+        // ── Async section: flush to IDB (no RefCell borrow held) ─────────────
+        if !dirty_pages.is_empty() {
+            let has_idb = self.inner.borrow().idb.is_some();
+            if has_idb {
+                let idb = self
+                    .inner
+                    .borrow()
+                    .idb
+                    .as_ref()
+                    .unwrap()
+                    .clone_handle();
+                idb.write_pages(dirty_pages).await?;
+            }
+        }
+
+        Ok(result_json)
+    }
+}
+
+// ── JSON serialisation helpers (free functions, not exported to WASM) ────────
+
+fn query_result_to_json(result: QueryResult) -> String {
+    use serde_json::{Value as JVal, json};
+
+    let val: JVal = match result {
+        QueryResult::Transacted(tx_id) => json!({"transacted": tx_id}),
+        QueryResult::Retracted(tx_id) => json!({"retracted": tx_id}),
+        QueryResult::Ok => json!({"ok": true}),
+        QueryResult::QueryResults { vars, results } => {
+            let rows: Vec<Vec<JVal>> = results
+                .iter()
+                .map(|row| row.iter().map(value_to_json).collect())
+                .collect();
+            json!({"variables": vars, "results": rows})
+        }
+    };
+    val.to_string()
+}
+
+fn value_to_json(v: &crate::graph::types::Value) -> serde_json::Value {
+    use crate::graph::types::Value;
+    use serde_json::Value as JVal;
+    match v {
+        Value::String(s) => JVal::String(s.clone()),
+        Value::Integer(i) => JVal::Number((*i).into()),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(JVal::Number)
+            .unwrap_or(JVal::Null),
+        Value::Boolean(b) => JVal::Bool(*b),
+        Value::Ref(uuid) => JVal::String(uuid.to_string()),
+        Value::Keyword(k) => JVal::String(k.clone()),
+        Value::Null => JVal::Null,
     }
 }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -5,3 +5,4 @@
 //! runtime. For Node.js, use `@minigraf/node` (Phase 8.3).
 
 pub mod buffer;
+pub mod indexeddb;

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -274,6 +274,7 @@ impl BrowserDb {
                     .map_err(|e| JsValue::from_str(&e.to_string()))?;
             }
 
+            inner.pfs.mark_dirty();
             inner
                 .pfs
                 .save()
@@ -352,5 +353,99 @@ fn value_to_json(v: &crate::graph::types::Value) -> serde_json::Value {
         Value::Ref(uuid) => JVal::String(uuid.to_string()),
         Value::Keyword(k) => JVal::String(k.clone()),
         Value::Null => JVal::Null,
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "browser", test))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    async fn in_memory_transact_and_query() {
+        let db = BrowserDb::open_in_memory().expect("open_in_memory");
+        let transact_result = db
+            .execute(r#"(transact [[:alice :name "Alice"] [:alice :age 30]])"#.to_string())
+            .await
+            .expect("transact");
+        let v: serde_json::Value = serde_json::from_str(&transact_result).unwrap();
+        assert!(v.get("transacted").is_some());
+
+        let query_result = db
+            .execute(r#"(query [:find ?name :where [:alice :name ?name]])"#.to_string())
+            .await
+            .expect("query");
+        let v: serde_json::Value = serde_json::from_str(&query_result).unwrap();
+        let results = v["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0][0], serde_json::Value::String("Alice".into()));
+    }
+
+    #[wasm_bindgen_test]
+    async fn empty_query_returns_empty_results() {
+        let db = BrowserDb::open_in_memory().expect("open_in_memory");
+        let result = db
+            .execute(r#"(query [:find ?e :where [?e :name _]])"#.to_string())
+            .await
+            .expect("query");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["results"].as_array().unwrap().len(), 0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn export_import_round_trip() {
+        let db = BrowserDb::open_in_memory().expect("open");
+        db.execute(r#"(transact [[:bob :role "admin"]])"#.to_string())
+            .await
+            .expect("transact");
+
+        let blob = db.export_graph().expect("export");
+        let bytes = blob.to_vec();
+        assert_eq!(&bytes[0..4], b"MGRF", "exported blob must start with MGRF magic");
+
+        let db2 = BrowserDb::open_in_memory().expect("open2");
+        db2.import_graph(blob).await.expect("import");
+
+        let result = db2
+            .execute(r#"(query [:find ?role :where [:bob :role ?role]])"#.to_string())
+            .await
+            .expect("query after import");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let results = v["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0][0], serde_json::Value::String("admin".into()));
+    }
+
+    #[wasm_bindgen_test]
+    async fn export_size_is_page_aligned() {
+        let db = BrowserDb::open_in_memory().expect("open");
+        db.execute(r#"(transact [[:e :v 1]])"#.to_string())
+            .await
+            .expect("transact");
+        let blob = db.export_graph().expect("export");
+        assert_eq!(blob.byte_length() as usize % crate::storage::PAGE_SIZE, 0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn idb_persistence_round_trip() {
+        let db_name = "minigraf-test-persistence";
+
+        let db1 = BrowserDb::open(db_name).await.expect("open db1");
+        db1.execute(r#"(transact [[:carol :dept "eng"]])"#.to_string())
+            .await
+            .expect("transact");
+        drop(db1);
+
+        let db2 = BrowserDb::open(db_name).await.expect("open db2");
+        let result = db2
+            .execute(r#"(query [:find ?dept :where [:carol :dept ?dept]])"#.to_string())
+            .await
+            .expect("query after reopen");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let results = v["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0][0], serde_json::Value::String("eng".into()));
     }
 }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -1,1 +1,7 @@
+//! Browser WASM support: `BrowserDb` async façade backed by IndexedDB.
+//!
+//! This module is only compiled for `wasm32-unknown-unknown` with the `browser`
+//! feature enabled. It is **not** compatible with Node.js or any server-side
+//! runtime. For Node.js, use `@minigraf/node` (Phase 8.3).
+
 pub mod buffer;

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,7 +14,7 @@ use crate::graph::types::{Fact, TxId, VALID_TIME_FOREVER};
 /// `i64::MIN` is chosen because it is not a representable Unix millisecond timestamp
 /// in any practical context, avoiding the collision that `0` would have with the Unix
 /// epoch (1970-01-01T00:00:00Z), which is a legitimate `valid_from` value.
-const VALID_FROM_USE_TX_TIME: i64 = i64::MIN;
+pub(crate) const VALID_FROM_USE_TX_TIME: i64 = i64::MIN;
 use crate::graph::FactStorage;
 use crate::graph::types::Value;
 use crate::query::datalog::evaluator::DEFAULT_MAX_DERIVED_FACTS;
@@ -648,7 +648,7 @@ impl Minigraf {
 
     /// Convert a `Transaction` into a list of assertion `Fact`s (tx_id and tx_count
     /// are set to 0 as placeholders; they are assigned at commit time).
-    fn materialize_transaction(tx: &Transaction) -> Result<Vec<Fact>> {
+    pub(crate) fn materialize_transaction(tx: &Transaction) -> Result<Vec<Fact>> {
         use crate::query::datalog::matcher::{edn_to_entity_id, edn_to_value};
         use crate::query::datalog::types::EdnValue;
 
@@ -687,7 +687,7 @@ impl Minigraf {
     }
 
     /// Convert a `Transaction` into a list of retraction `Fact`s.
-    fn materialize_retraction(tx: &Transaction) -> Result<Vec<Fact>> {
+    pub(crate) fn materialize_retraction(tx: &Transaction) -> Result<Vec<Fact>> {
         use crate::query::datalog::matcher::{edn_to_entity_id, edn_to_value};
         use crate::query::datalog::types::EdnValue;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,11 +28,14 @@ use crate::query::datalog::parser::parse_datalog_command;
 use crate::query::datalog::rules::RuleRegistry;
 use crate::query::datalog::types::{AttributeSpec, DatalogCommand, Transaction};
 use crate::storage::backend::MemoryBackend;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::storage::backend::file::FileBackend;
 use crate::storage::persistent_facts::PersistentFactStorage;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::wal::WalWriter;
 use anyhow::{Result, bail};
 use std::any::Any;
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
@@ -115,6 +118,7 @@ impl OpenOptions {
     }
 
     /// Set the path for a file-backed database.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn path(self, path: impl AsRef<Path>) -> OpenOptionsWithPath {
         OpenOptionsWithPath {
             opts: self,
@@ -131,11 +135,13 @@ impl OpenOptions {
 }
 
 /// `OpenOptions` combined with a file path, ready to open.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct OpenOptionsWithPath {
     opts: OpenOptions,
     path: PathBuf,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl OpenOptionsWithPath {
     /// Open or create the file-backed database.
     pub fn open(self) -> Result<Minigraf> {
@@ -150,6 +156,7 @@ enum WriteContext {
     /// In-memory database: no WAL, no persistence.
     Memory,
     /// File-backed database: has a WAL sidecar and a persistent storage layer.
+    #[cfg(not(target_arch = "wasm32"))]
     File {
         pfs: PersistentFactStorage<FileBackend>,
         /// WAL writer. `None` after a checkpoint until the next write.
@@ -250,11 +257,13 @@ impl Minigraf {
     ///
     /// A sidecar WAL file (`<path>.wal`) is created alongside the main file.
     /// Any existing WAL from a previous crash is replayed automatically.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         Self::open_with_options(path, OpenOptions::default())
     }
 
     /// Open or create a file-backed database with custom options.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn open_with_options(path: impl AsRef<Path>, opts: OpenOptions) -> Result<Self> {
         let db_path = path.as_ref().to_path_buf();
 
@@ -330,6 +339,7 @@ impl Minigraf {
     /// Replay any WAL entries that are newer than the main file's checkpoint.
     ///
     /// Returns the number of entries replayed (used to seed `wal_entry_count`).
+    #[cfg(not(target_arch = "wasm32"))]
     fn replay_wal(
         wal_path: &Path,
         fact_storage: &FactStorage,
@@ -535,6 +545,7 @@ impl Minigraf {
             WriteContext::Memory => {
                 // No-op for in-memory databases.
             }
+            #[cfg(not(target_arch = "wasm32"))]
             WriteContext::File {
                 pfs,
                 wal,
@@ -618,6 +629,7 @@ impl Minigraf {
     }
 
     /// Compute the WAL sidecar path for a given database path.
+    #[cfg(not(target_arch = "wasm32"))]
     fn wal_path_for(db_path: &Path) -> PathBuf {
         let mut p = db_path.to_path_buf();
         let name = p
@@ -983,6 +995,7 @@ impl<'a> WriteTransaction<'a> {
     ) -> Result<bool> {
         match ctx {
             WriteContext::Memory => Ok(false),
+            #[cfg(not(target_arch = "wasm32"))]
             WriteContext::File {
                 pfs,
                 wal,

--- a/src/db.rs
+++ b/src/db.rs
@@ -209,10 +209,12 @@ impl Drop for Inner {
 ///
 /// # File-backed usage
 /// ```no_run
+/// # #[cfg(not(target_arch = "wasm32"))] {
 /// use minigraf::db::Minigraf;
 ///
 /// let db = Minigraf::open("mydb.graph").unwrap();
 /// db.execute(r#"(transact [[:alice :person/name "Alice"]])"#).unwrap();
+/// # }
 /// ```
 ///
 /// # In-memory usage
@@ -1068,7 +1070,7 @@ impl Drop for WriteTransaction<'_> {
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -987,6 +987,7 @@ impl<'a> WriteTransaction<'a> {
     /// Returns `true` if an auto-checkpoint should be triggered.  The caller is
     /// responsible for applying facts to `FactStorage` **before** triggering the
     /// checkpoint, so that the checkpoint captures the newly written facts.
+    #[allow(unused_variables)]
     fn wal_write_stamped_batch(
         ctx: &mut WriteContext,
         opts: &OpenOptions,

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -15,10 +15,20 @@ pub(crate) type TxId = u64;
 
 /// Get current timestamp as transaction ID (milliseconds since UNIX epoch)
 pub(crate) fn tx_id_now() -> TxId {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time before UNIX epoch")
-        .as_millis() as u64
+    #[cfg(all(target_arch = "wasm32", feature = "browser"))]
+    {
+        // On WASM browser targets, `std::time::SystemTime::now()` panics.
+        // Use `js_sys::Date::now()` which returns milliseconds since the Unix
+        // epoch as an f64 (same precision as `Date.now()` in JavaScript).
+        js_sys::Date::now() as u64
+    }
+    #[cfg(not(all(target_arch = "wasm32", feature = "browser")))]
+    {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time before UNIX epoch")
+            .as_millis() as u64
+    }
 }
 
 /// A unique identifier for a graph entity (UUID v4).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,9 @@ pub(crate) mod wal;
 #[cfg(all(target_arch = "wasm32", feature = "browser"))]
 pub mod browser;
 
-pub use db::{Minigraf, OpenOptions, WriteTransaction};
 #[cfg(not(target_arch = "wasm32"))]
 pub use db::OpenOptionsWithPath;
+pub use db::{Minigraf, OpenOptions, WriteTransaction};
 pub use repl::Repl;
 
 // EAV value types — users construct and match on these

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub(crate) mod storage;
 pub(crate) mod temporal;
 pub(crate) mod wal;
 
+#[cfg(all(target_arch = "wasm32", feature = "browser"))]
+pub mod browser;
+
 pub use db::{Minigraf, OpenOptions, OpenOptionsWithPath, WriteTransaction};
 pub use repl::Repl;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,9 @@ pub(crate) mod wal;
 #[cfg(all(target_arch = "wasm32", feature = "browser"))]
 pub mod browser;
 
-pub use db::{Minigraf, OpenOptions, OpenOptionsWithPath, WriteTransaction};
+pub use db::{Minigraf, OpenOptions, WriteTransaction};
+#[cfg(not(target_arch = "wasm32"))]
+pub use db::OpenOptionsWithPath;
 pub use repl::Repl;
 
 // EAV value types — users construct and match on these

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,32 @@
-use minigraf::{Minigraf, OpenOptions};
+#[cfg(not(target_arch = "wasm32"))]
+use minigraf::OpenOptions;
+#[cfg(not(target_arch = "wasm32"))]
+use minigraf::Minigraf;
 
 fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-    let file_flag_pos = args.iter().position(|a| a == "--file");
-    let db_path = file_flag_pos.and_then(|i| args.get(i + 1)).cloned();
-
-    if file_flag_pos.is_some() && db_path.is_none() {
-        eprintln!("error: --file requires a path argument");
-        std::process::exit(1);
+    #[cfg(target_arch = "wasm32")]
+    {
+        // The REPL binary is not applicable to WASM targets.
+        Ok(())
     }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let args: Vec<String> = std::env::args().collect();
+        let file_flag_pos = args.iter().position(|a| a == "--file");
+        let db_path = file_flag_pos.and_then(|i| args.get(i + 1)).cloned();
 
-    let db = if let Some(path) = db_path {
-        OpenOptions::new().path(path).open()?
-    } else {
-        Minigraf::in_memory()?
-    };
+        if file_flag_pos.is_some() && db_path.is_none() {
+            eprintln!("error: --file requires a path argument");
+            std::process::exit(1);
+        }
 
-    db.repl().run();
-    Ok(())
+        let db = if let Some(path) = db_path {
+            OpenOptions::new().path(path).open()?
+        } else {
+            Minigraf::in_memory()?
+        };
+
+        db.repl().run();
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
-use minigraf::OpenOptions;
-#[cfg(not(target_arch = "wasm32"))]
 use minigraf::Minigraf;
+#[cfg(not(target_arch = "wasm32"))]
+use minigraf::OpenOptions;
 
 fn main() -> anyhow::Result<()> {
     #[cfg(target_arch = "wasm32")]

--- a/src/storage/backend/file.rs
+++ b/src/storage/backend/file.rs
@@ -176,7 +176,7 @@ impl StorageBackend for FileBackend {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 

--- a/src/storage/backend/mod.rs
+++ b/src/storage/backend/mod.rs
@@ -16,3 +16,6 @@ pub use memory::MemoryBackend;
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(unused_imports)]
 pub use file::FileBackend;
+
+#[cfg(all(target_arch = "wasm32", feature = "browser"))]
+pub use crate::browser::buffer::BrowserBufferBackend;

--- a/src/storage/persistent_facts.rs
+++ b/src/storage/persistent_facts.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// Sorts facts by `(tx_count, entity_bytes, attribute)` before hashing to
 /// produce a stable total order independent of Vec insertion order.
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 fn compute_index_checksum(facts: &[Fact]) -> u32 {
     let mut sorted: Vec<&Fact> = facts.iter().collect();
     sorted.sort_by(|a, b| {
@@ -1082,7 +1082,7 @@ fn build_sorted_index_entries(
     (eavt, aevt, avet, vaet)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use crate::graph::types::Value;

--- a/src/storage/persistent_facts.rs
+++ b/src/storage/persistent_facts.rs
@@ -912,6 +912,29 @@ impl<B: StorageBackend + 'static> PersistentFactStorage<B> {
     pub fn is_dirty(&self) -> bool {
         self.dirty
     }
+
+    /// Run a closure with read access to the underlying storage backend.
+    ///
+    /// Used by the browser WASM layer to read pages after `save()` without
+    /// exposing the `Arc<Mutex<B>>` directly.
+    pub(crate) fn with_backend<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&B) -> R,
+    {
+        let guard = self.backend.lock().unwrap();
+        f(&*guard)
+    }
+
+    /// Run a closure with mutable access to the underlying storage backend.
+    ///
+    /// Used by the browser WASM layer to drain dirty pages after `save()`.
+    pub(crate) fn with_backend_mut<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut B) -> R,
+    {
+        let mut guard = self.backend.lock().unwrap();
+        f(&mut *guard)
+    }
 }
 
 impl<B: StorageBackend + 'static> Drop for PersistentFactStorage<B> {

--- a/src/storage/persistent_facts.rs
+++ b/src/storage/persistent_facts.rs
@@ -917,6 +917,7 @@ impl<B: StorageBackend + 'static> PersistentFactStorage<B> {
     ///
     /// Used by the browser WASM layer to read pages after `save()` without
     /// exposing the `Arc<Mutex<B>>` directly.
+    #[cfg(all(target_arch = "wasm32", feature = "browser"))]
     pub(crate) fn with_backend<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&B) -> R,
@@ -928,6 +929,7 @@ impl<B: StorageBackend + 'static> PersistentFactStorage<B> {
     /// Run a closure with mutable access to the underlying storage backend.
     ///
     /// Used by the browser WASM layer to drain dirty pages after `save()`.
+    #[cfg(all(target_arch = "wasm32", feature = "browser"))]
     pub(crate) fn with_backend_mut<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut B) -> R,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -292,7 +292,7 @@ impl WalReader {
 
 // ─── Unit tests ─────────────────────────────────────────────────────────────
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use crate::graph::types::{VALID_TIME_FOREVER, Value};

--- a/tests/btree_v6_test.rs
+++ b/tests/btree_v6_test.rs
@@ -1,4 +1,5 @@
 //! Integration tests for Phase 6.5: on-disk B+tree indexes (file format v6).
+#![cfg(not(target_arch = "wasm32"))]
 
 use minigraf::OpenOptions;
 use tempfile::NamedTempFile;

--- a/tests/edge_cases_test.rs
+++ b/tests/edge_cases_test.rs
@@ -4,6 +4,7 @@
 //! - Oversized fact rejected at insertion (file-backed, both execute() and commit() paths)
 //! - Oversized fact accepted in-memory (no page size constraint)
 //! - Stale WAL after checkpoint is replayed idempotently (no duplicate facts)
+#![cfg(not(target_arch = "wasm32"))]
 
 use minigraf::{Minigraf, OpenOptions, QueryResult};
 

--- a/tests/index_test.rs
+++ b/tests/index_test.rs
@@ -7,6 +7,7 @@
 //! - Transaction-time as-of queries still work correctly
 //! - Recursive rules are unaffected by the index layer
 //! - Explicit write transactions work correctly with indexes
+#![cfg(not(target_arch = "wasm32"))]
 
 use minigraf::db::Minigraf;
 use minigraf::{QueryResult, Value};

--- a/tests/performance_test.rs
+++ b/tests/performance_test.rs
@@ -1,4 +1,5 @@
 //! Integration tests for Phase 6.2 packed pages.
+#![cfg(not(target_arch = "wasm32"))]
 
 use minigraf::{Minigraf, OpenOptions};
 use tempfile::NamedTempFile;

--- a/tests/wal_test.rs
+++ b/tests/wal_test.rs
@@ -10,6 +10,7 @@
 //! - Explicit transaction commit and rollback
 //! - Concurrent reads while writer holds the write lock
 //! - V2 → V3 file format upgrade on first checkpoint
+#![cfg(not(target_arch = "wasm32"))]
 
 use minigraf::QueryResult;
 use minigraf::db::{Minigraf, OpenOptions};


### PR DESCRIPTION
Closes #129

## Summary

- Adds a `browser` cargo feature compiling Minigraf for `wasm32-unknown-unknown` with a new `BrowserDb` async façade exposed via `wasm-bindgen`
- Persistence via two-layer design: `BrowserBufferBackend` (sync `HashMap`-backed `StorageBackend`) absorbs `PersistentFactStorage::save()` writes; `IndexedDbBackend` flushes dirty pages to IndexedDB in a single batched `readwrite` transaction per `execute()` call
- Public JS API: `BrowserDb.open(dbName)`, `BrowserDb.openInMemory()`, `execute(datalog)`, `checkpoint()`, `exportGraph()`, `importGraph(bytes)` — all returning Promises
- Export/import produces byte-for-bit compatible `.graph` blobs (MGRF magic, ascending page order); round-trip verified by integration test
- `wasm-bindgen-test` integration tests run in headless Chrome **and** Firefox via new `.github/workflows/wasm-browser.yml` CI matrix
- All existing 792 native tests continue to pass; no public API changes; file format unchanged

## Test plan

- [ ] `cargo test` — all 792 native tests pass
- [ ] `cargo check --target wasm32-unknown-unknown --features browser` — clean
- [ ] `cargo clippy` and `cargo clippy --target wasm32-unknown-unknown --features browser` — clean
- [ ] `cargo fmt --check` — clean
- [ ] CI wasm-browser workflow passes on Chrome and Firefox headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)