### PR TITLE
fix(bench): restore panic = "unwind" in bench profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ strip = "none"
 debug = true
 lto = true
 codegen-units = 1
+panic = "unwind"
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

- Commit 8219981 removed `panic = "unwind"` from `[profile.bench]` expecting the built-in bench default to apply
- With `lto = true`, Cargo reuses release artifacts compiled with `panic = "abort"`, causing a strategy mismatch and `cargo bench --no-run` failure
- Restores the explicit `panic = "unwind"` setting — verified locally: `cargo bench --no-run` now compiles successfully

## Test plan

- [x] `cargo bench --no-run` compiles without panic strategy errors locally
- [ ] CI `bench / compile` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)