### PR TITLE
feat(wasi): Phase 8.1b — wasm32-wasip1 server-side WASM support

### DIFF
--- a/.github/workflows/wasm-wasi.yml
+++ b/.github/workflows/wasm-wasi.yml
@@ -1,0 +1,66 @@
+name: WASM WASI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+  WASMTIME_VERSION: v33.0.0
+  WASMER_VERSION: v5.0.4
+
+permissions:
+  contents: read
+
+jobs:
+  wasm-wasi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: Build (release)
+        run: cargo build --target wasm32-wasip1 --release --bin minigraf
+
+      - name: Install Wasmtime
+        run: |
+          curl -sSfL \
+            "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz" \
+            -o /tmp/wasmtime.tar.xz
+          tar -xf /tmp/wasmtime.tar.xz -C /tmp
+          echo "/tmp/wasmtime-${WASMTIME_VERSION}-x86_64-linux" >> "$GITHUB_PATH"
+
+      - name: Run WASI tests (Wasmtime runner)
+        run: cargo test --target wasm32-wasip1 --lib
+        env:
+          CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime run --dir /tmp
+
+      - name: Smoke test — Wasmtime transact + query
+        run: |
+          out=$(printf '(transact [{:db/id "eid-1" :name "Alice"}])\n(query [:find ?e :where [?e :name _]])\n' | \
+            wasmtime run --dir /tmp \
+              target/wasm32-wasip1/release/minigraf.wasm)
+          echo "$out"
+          echo "$out" | grep -q "result(s) found" || { echo "SMOKE TEST FAILED: no results in output"; exit 1; }
+
+      - name: Install Wasmer
+        run: |
+          curl -sSfL \
+            "https://github.com/wasmerio/wasmer/releases/download/${WASMER_VERSION}/wasmer-linux-amd64.tar.gz" \
+            -o /tmp/wasmer.tar.gz
+          mkdir -p /tmp/wasmer-install
+          tar -xf /tmp/wasmer.tar.gz -C /tmp/wasmer-install bin/wasmer
+          echo "/tmp/wasmer-install/bin" >> "$GITHUB_PATH"
+
+      - name: Smoke test — Wasmer transact + query
+        run: |
+          out=$(printf '(transact [{:db/id "eid-1" :name "Alice"}])\n(query [:find ?e :where [?e :name _]])\n' | \
+            wasmer run --dir /tmp \
+              target/wasm32-wasip1/release/minigraf.wasm)
+          echo "$out"
+          echo "$out" | grep -q "result(s) found" || { echo "SMOKE TEST FAILED: no results in output"; exit 1; }

--- a/.github/workflows/wasm-wasi.yml
+++ b/.github/workflows/wasm-wasi.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Smoke test — Wasmtime transact + query
         run: |
-          out=$(printf '(transact [{:db/id "eid-1" :name "Alice"}])\n(query [:find ?e :where [?e :name _]])\n' | \
+          out=$(printf '(transact [[:alice :name "Alice"]])\n(query [:find ?e :where [?e :name _]])\n' | \
             wasmtime run --dir /tmp \
               target/wasm32-wasip1/release/minigraf.wasm)
           echo "$out"
@@ -59,7 +59,7 @@ jobs:
 
       - name: Smoke test — Wasmer transact + query
         run: |
-          out=$(printf '(transact [{:db/id "eid-1" :name "Alice"}])\n(query [:find ?e :where [?e :name _]])\n' | \
+          out=$(printf '(transact [[:alice :name "Alice"]])\n(query [:find ?e :where [?e :name _]])\n' | \
             wasmer run --dir /tmp \
               target/wasm32-wasip1/release/minigraf.wasm)
           echo "$out"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 regex-lite = "0.1.9"
 serde_json = { version = "1.0", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 uuid                 = { version = "1.0", features = ["v4", "v5", "serde", "js"] }
 wasm-bindgen         = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
@@ -57,7 +57,7 @@ serde_json = "1.0"
 tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Offline-first storage with retroactive corrections — the bi-temporal model let
 
 ### For WASM / Browser
 
-Phase 8 target: page-granular IndexedDB backend, `wasm-pack` packaging, npm release as `@minigraf/core`. Also supports server-side WASM via WASI.
+Phase 8.1a complete: IndexedDB backend, `wasm-pack` packaging. Phase 8.1b complete: server-side WASM via `wasm32-wasip1` / WASI (Wasmtime, Wasmer). npm release as `@minigraf/core` planned for Phase 8.2.
 
 See the [Use Cases](https://github.com/adityamukho/minigraf/wiki/Use-Cases) wiki page for detailed guides on all three targets.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ No other database offers this combination:
 | **Embedded** | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No | ✅ Yes |
 | **Graph Native** | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
 | **Rust** | ✅ Yes | ❌ Clojure | ✅ Yes | ❌ Java | ❌ C |
-| **WASM Ready** | 🎯 Phase 8 | ❌ No | ⚠️ Limited | ❌ No | ✅ Yes |
+| **WASM Ready** | ✅ Phase 8.1a/b | ❌ No | ⚠️ Limited | ❌ No | ✅ Yes |
 
 **Embedded graph memory for agents, mobile, and the browser — SQLite's simplicity + Datomic's temporal model.**
 
@@ -140,7 +140,7 @@ See the [Use Cases](https://github.com/adityamukho/minigraf/wiki/Use-Cases) wiki
 Minigraf runs as:
 - ✅ An embedded library
 - ✅ A standalone binary (interactive REPL)
-- 🎯 A WebAssembly module (Phase 8)
+- ✅ A WebAssembly module — browser (`wasm32-unknown-unknown`) and server-side WASI (`wasm32-wasip1`) (Phase 8.1a/b complete)
 
 Minigraf will **not** be (by design):
 - **Distributed** — no clustering, no sharding, no replication; each agent instance owns its own `.graph` file

--- a/src/db.rs
+++ b/src/db.rs
@@ -1743,7 +1743,7 @@ mod wasi_tests {
     #[test]
     fn in_memory_smoke() {
         let db = Minigraf::in_memory().expect("open in-memory db");
-        db.execute(r#"(transact [{:db/id "e1" :name "hello"}])"#)
+        db.execute("(transact [[:e1 :name \"hello\"]])")
             .expect("transact");
         let r = db
             .execute("(query [:find ?e :where [?e :name _]])")

--- a/src/db.rs
+++ b/src/db.rs
@@ -1728,3 +1728,31 @@ mod tests {
         assert!(result.is_ok(), "Query should succeed with higher limit");
     }
 }
+
+// ─── WASI smoke test ─────────────────────────────────────────────────────────
+// Gated to target_os = "wasi" only. Regular #[test] works here because
+// cargo test --target wasm32-wasip1 uses Wasmtime as the runner
+// (CARGO_TARGET_WASM32_WASIP1_RUNNER). Not gated on target_arch = "wasm32"
+// because the browser target (wasm32-unknown-unknown) requires
+// #[wasm_bindgen_test] instead, which is a separate harness.
+#[cfg(all(target_os = "wasi", test))]
+mod wasi_tests {
+    use crate::db::Minigraf;
+    use crate::query::datalog::executor::QueryResult;
+
+    #[test]
+    fn in_memory_smoke() {
+        let db = Minigraf::in_memory().expect("open in-memory db");
+        db.execute(r#"(transact [{:db/id "e1" :name "hello"}])"#)
+            .expect("transact");
+        let r = db
+            .execute("(query [:find ?e :where [?e :name _]])")
+            .expect("query");
+        match r {
+            QueryResult::QueryResults { results, .. } => {
+                assert!(!results.is_empty());
+            }
+            _ => panic!("expected QueryResults"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,18 @@
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 use minigraf::Minigraf;
 #[cfg(not(target_arch = "wasm32"))]
 use minigraf::OpenOptions;
 
 fn main() -> anyhow::Result<()> {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_os = "wasi")]
     {
-        // The REPL binary is not applicable to WASM targets.
+        let db = Minigraf::in_memory()?;
+        db.repl().run();
+        Ok(())
+    }
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+    {
+        // Browser WASM — entry point is the BrowserDb JS/WASM API, not a REPL binary.
         Ok(())
     }
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/storage/btree_v6.rs
+++ b/src/storage/btree_v6.rs
@@ -1049,6 +1049,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "wasi"))]
     fn test_concurrent_range_scans_correctness() {
         use crate::storage::CommittedIndexReader;
         use std::sync::{Arc, Barrier};

--- a/src/storage/cache.rs
+++ b/src/storage/cache.rs
@@ -228,6 +228,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "wasi"))]
     fn test_concurrent_reads() {
         use std::sync::Arc;
         use std::thread;


### PR DESCRIPTION
Closes #130.

## What

Compiles Minigraf to `wasm32-wasip1` with a working in-memory REPL, tested in CI by both Wasmtime and Wasmer.

## Changes

- **`Cargo.toml`**: Narrowed `target_arch = "wasm32"` dep/dev-dep blocks to `all(target_arch = "wasm32", not(target_os = "wasi"))` — prevents `uuid`'s `js` feature (and `wasm-bindgen-test`) from applying to WASI targets where there is no JavaScript engine.
- **`src/main.rs`**: Added `#[cfg(target_os = "wasi")]` branch that opens an in-memory database and runs the REPL. File-backed storage is out of scope for WASI (in-memory only per design decision).
- **`src/db.rs`**: Added `#[cfg(all(target_os = "wasi", test))]` smoke test, run via `CARGO_TARGET_WASM32_WASIP1_RUNNER`.
- **`.github/workflows/wasm-wasi.yml`**: Rewrote as a single job: build → WASI unit tests (`--lib` via Wasmtime runner) → Wasmtime smoke (transact + query, output verified) → Wasmer smoke (transact + query, output verified).
- **`.wiki/Use-Cases.md`**: Added Phase 8.1a `BrowserDb` usage guide and Phase 8.1b WASI section (build/run/constraints/embedding). Pushed to wiki repo separately.
- **`README.md`**: Updated phase status markers to reflect 8.1a/b complete.

## Design decisions

- **In-memory only for WASI**: File-backed storage under WASI would require threading `FileBackend`/WAL through new cfg gates across `db.rs`, `lib.rs`, `storage/` — significant complexity for a use case better served by native binaries. WASI value is as an embeddable library.
- **`target_os = "wasi"` not `target_arch = "wasm32"`**: The broader gate also fires for browser WASM (`wasm32-unknown-unknown`) where `wasm-pack` requires `#[wasm_bindgen_test]` not `#[test]`. WASI-specific gating keeps targets cleanly separated.
- **`cargo test --lib`**: Integration tests in `tests/` include `concurrency_test.rs` which uses `std::thread::spawn` — unsupported under WASI Preview 1. `--lib` scopes the run to in-crate tests only.

## Testing sign-off checklist

- [ ] `cargo build --target wasm32-wasip1 --release` succeeds (CI)
- [ ] `cargo test --target wasm32-wasip1 --lib` passes via Wasmtime runner (CI)
- [ ] Wasmtime smoke test (transact + query, output verified) passes (CI)
- [ ] Wasmer smoke test (transact + query, output verified) passes (CI)
- [ ] `cargo test` (native) still passes (CI)
- [ ] `cargo build --target wasm32-unknown-unknown --features browser` still passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)