### PR TITLE
fix(docs): expose browser module on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.20.1 — Patch: docs.rs browser module visibility (2026-04-19)
+
+### Fixed
+- `browser` module now appears on docs.rs: added `docsrs` to the `cfg` gate and `doc(cfg(...))` badge annotation (`src/lib.rs`)
+
 ## v0.20.0 — Phase 8.1: WebAssembly Support (2026-04-18)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 description = "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@ pub(crate) mod storage;
 pub(crate) mod temporal;
 pub(crate) mod wal;
 
-#[cfg(all(target_arch = "wasm32", feature = "browser"))]
+#[cfg(any(all(target_arch = "wasm32", feature = "browser"), docsrs))]
+#[cfg_attr(docsrs, doc(cfg(all(target_arch = "wasm32", feature = "browser"))))]
 pub mod browser;
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary

- `pub mod browser` was gated on `target_arch = \"wasm32\"`, which is never true on docs.rs (x86_64 host), so the entire module was invisible in generated docs
- Added `docsrs` to the cfg condition so the module compiles during doc builds
- Added `#[cfg_attr(docsrs, doc(cfg(...)))]` to render the correct "Available on wasm32 + browser feature only" badge

## Test Plan

- [x] `cargo test` — 795 tests passing, 0 failures
- [x] Pre-push hooks (fmt, clippy, test) all green
- [ ] Verify `browser` module appears on docs.rs after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)