### PR TITLE
fix(docs): exclude browser module from x86_64 docs.rs build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,19 @@ on:
       - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
+  # Verify docs.rs build passes before publishing
+  docs-check:
+    runs-on: "ubuntu-22.04"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Check docs.rs build
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs"
+        run: cargo doc --all-features --no-deps
+
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
     runs-on: "ubuntu-22.04"
@@ -218,8 +231,9 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+      - docs-check
     # Only run if we're "publishing", and only if all build jobs didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && needs.docs-check.result == 'success' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,3 +35,13 @@ jobs:
       run: cargo check -p minigraf-ffi
     - name: Run FFI native tests
       run: cargo test -p minigraf-ffi
+
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
+    - name: Check docs.rs build
+      env:
+        RUSTDOCFLAGS: "--cfg docsrs"
+      run: cargo doc --all-features --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ wasm-opt = false
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub(crate) mod storage;
 pub(crate) mod temporal;
 pub(crate) mod wal;
 
-#[cfg(any(all(target_arch = "wasm32", feature = "browser"), docsrs))]
+#[cfg(all(target_arch = "wasm32", feature = "browser"))]
 #[cfg_attr(docsrs, doc(cfg(all(target_arch = "wasm32", feature = "browser"))))]
 pub mod browser;
 


### PR DESCRIPTION
## Summary

- Remove `docsrs` cfg from the browser module gate in `src/lib.rs` — the module now only compiles when `target_arch = "wasm32"` is satisfied, not on the x86_64 docs.rs host
- Add `targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]` to `[package.metadata.docs.rs]` so docs.rs generates docs for both native and WASM targets

## Root Cause

`[package.metadata.docs.rs]` had `all-features = true`. On the x86_64 host, this enabled the `browser` feature and `--cfg docsrs` caused the browser module to be included in compilation. But `wasm-bindgen`/`web-sys`/`js-sys` are `[target.'cfg(target_arch = "wasm32")'.dependencies]` and are absent on x86_64, producing ~25 compile errors.

## Test Plan
- [x] `cargo test` — 815 tests passing, 0 failures
- [ ] Trigger a new docs.rs build and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)