### PR TITLE
docs(lib): add Feature Flags section for browser/WASM targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,23 @@ Pairs well with vector stores (GraphRAG pattern): the vector store answers "what
 
 ### For Mobile Apps
 
-Offline-first storage with retroactive corrections — the bi-temporal model lets you correct a mis-entered value while preserving the original record. Phase 8 will ship iOS `.xcframework` and Android `.aar` via UniFFI.
+Offline-first storage with retroactive corrections — the bi-temporal model lets you correct a mis-entered value while preserving the original record. Native Kotlin and Swift bindings ship as an Android `.aar` (GitHub Packages) and an iOS `.xcframework` (Swift Package Manager) via [UniFFI](https://github.com/mozilla/uniffi-rs). No Rust required.
+
+```kotlin
+// Android (Kotlin)
+val db = MiniGrafDb.open(context.filesDir.absolutePath + "/myapp.graph")
+db.execute("""(transact [[:alice :person/name "Alice"] [:alice :person/age 30]])""")
+val json = db.execute("(query [:find ?name :where [?e :person/name ?name]])")
+```
+
+```swift
+// iOS (Swift)
+let db = try MiniGrafDb.open(path: docsURL.appendingPathComponent("myapp.graph").path)
+try db.execute(datalog: #"(transact [[:alice :person/name "Alice"] [:alice :person/age 30]])"#)
+let json = try db.execute(datalog: "(query [:find ?name :where [?e :person/name ?name]])")
+```
+
+See the [Mobile Integration](https://github.com/adityamukho/minigraf/wiki/Use-Cases#mobile-apps) wiki section for full setup and usage docs (Gradle config, SPM integration, error handling, threading).
 
 ### For WASM / Browser
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,22 @@
 //! // Time travel — query the state as of transaction 1
 //! db.execute("(query [:find ?age :as-of 1 :where [:alice :person/age ?age]])").unwrap();
 //! ```
+//!
+//! # Feature Flags
+//!
+//! | Feature | Target | Description |
+//! |---------|--------|-------------|
+//! | *(default)* | native / WASI | File-backed and in-memory databases; full Datalog engine |
+//! | `browser` | `wasm32-unknown-unknown` | Enables the `browser` module (`BrowserDb`), backed by IndexedDB for use inside a web browser via `wasm-pack` |
+//!
+//! The `browser` feature is only meaningful on the `wasm32-unknown-unknown` target.
+//! When browsing docs on [docs.rs](https://docs.rs/minigraf), switch the target to
+//! `wasm32-unknown-unknown` (top-right target selector) to see the full browser API.
+//!
+//! ## WebAssembly targets
+//!
+//! - **Browser** (`wasm32-unknown-unknown` + `browser` feature) — `wasm-pack build --target web --features browser`
+//! - **WASI / server-side** (`wasm32-wasip1`) — `cargo build --target wasm32-wasip1 --release --bin minigraf`
 
 pub mod db;
 pub(crate) mod graph;


### PR DESCRIPTION
## Summary

- Adds a **Feature Flags** table to the crate-level docs (`src/lib.rs`) listing the `browser` feature and its `wasm32-unknown-unknown` target
- Adds a **WebAssembly targets** subsection with the exact build commands for browser (`wasm-pack`) and WASI (`wasm32-wasip1`)
- Notes that the full browser API is visible by switching the target selector on docs.rs to `wasm32-unknown-unknown`

Previously, the docs.rs landing page had no mention of WASM support at all. Android/iOS usage docs are intentionally kept out of docs.rs (they're for non-Rust consumers and belong in README/wiki).

## Test plan
- [ ] `cargo doc --all-features --no-deps` builds with no warnings (verified locally)
- [ ] docs-check CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)