### PR TITLE
fix(ci): remove pull_request trigger from Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'


### PR DESCRIPTION
## Summary

- The `release.yml` workflow had a bare `pull_request:` trigger alongside the version-tag push trigger
- This caused the Release workflow to run on every PR (as seen in run [#24939431279](https://github.com/project-minigraf/minigraf/actions/runs/24939431279))
- Removed the `pull_request:` trigger — the workflow now only fires on version tags matching `**[0-9]+.[0-9]+.[0-9]+*`

## Test plan

- [ ] Verify no Release workflow run is triggered when this PR is opened
- [ ] Verify Release workflow still fires when a version tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)