### PR TITLE
feat(node): Phase 8.3d — Node.js bindings on npm (v0.25.0)

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,39 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Node.js tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install npm dependencies
+        working-directory: minigraf-node
+        run: npm install
+
+      - name: Build native addon
+        working-directory: minigraf-node
+        run: npx @napi-rs/cli build --platform --release
+
+      - name: Run tests
+        working-directory: minigraf-node
+        run: node --test test/basic.test.mjs

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -82,6 +82,10 @@ jobs:
           path: minigraf-node
           merge-multiple: true
 
+      - name: Move artifacts into platform packages
+        working-directory: minigraf-node
+        run: npx @napi-rs/cli artifacts
+
       - name: Publish platform packages
         working-directory: minigraf-node
         env:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -1,0 +1,95 @@
+name: Node.js Release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build .node binary (${{ matrix.settings.host }})
+    runs-on: ${{ matrix.settings.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            npm-package: '@minigraf/linux-x64-gnu'
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            npm-package: '@minigraf/linux-arm64-gnu'
+          - host: macos-14
+            target: universal-apple-darwin
+            npm-package: '@minigraf/darwin-universal'
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            npm-package: '@minigraf/win32-x64-msvc'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target == 'universal-apple-darwin' && 'aarch64-apple-darwin x86_64-apple-darwin' || matrix.settings.target }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm dependencies
+        working-directory: minigraf-node
+        run: npm install
+
+      - name: Build native addon
+        working-directory: minigraf-node
+        run: npx @napi-rs/cli build --platform --release --target ${{ matrix.settings.target }}
+
+      - name: Upload .node binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-binary-${{ matrix.settings.npm-package }}
+          path: minigraf-node/*.node
+
+  publish:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download all binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: node-binary-*
+          path: minigraf-node
+          merge-multiple: true
+
+      - name: Publish platform packages
+        working-directory: minigraf-node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx @napi-rs/cli publish --prefix packages
+
+      - name: Publish main minigraf package
+        working-directory: minigraf-node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,3 +349,15 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+
+  # Build and publish Node.js bindings to npm after the release is created
+  publish-node:
+    name: Publish Node.js bindings to npm
+    needs:
+      - plan
+      - host
+    if: ${{ always() && needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' }}
+    uses: ./.github/workflows/node-release.yml
+    with:
+      tag: ${{ needs.plan.outputs.tag }}
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] — 2026-04-26
+
+### Added
+- **Phase 8.3d**: Node.js bindings published to npm as `minigraf`.
+  Install with `npm install minigraf`. No build step required — prebuilt
+  `.node` binaries for Linux x86_64/aarch64, macOS universal2, Windows x86_64.
+  API: `new MiniGrafDb(path)`, `MiniGrafDb.inMemory()`, `.execute(datalog)`,
+  `.checkpoint()`. Full TypeScript definitions included.
+
 ## v0.24.0 — Phase 8.3c: C Bindings (2026-04-26)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.0] — 2026-04-26
+## v0.25.0 — 2026-04-26
 
 ### Added
 - **Phase 8.3d**: Node.js bindings published to npm as `minigraf`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "minigraf-ffi", "minigraf-c"]
+members = [".", "minigraf-ffi", "minigraf-c", "minigraf-node"]
 resolver = "2"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "minigraf"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 description = "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries"
 license = "MIT OR Apache-2.0"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1261,7 +1261,7 @@ MinigrafKit-v0.9.0.zip            ← Swift Package Manager checksum source
 - 🎯 `register_aggregate` / `register_predicate` over UniFFI — requires closure-passing across FFI (not supported by UniFFI 0.31.1); needs a callback-based redesign
 - 🎯 `prepare()` / `PreparedQuery` over UniFFI — bind-slot substitution requires a stateful handle; design TBD once basic FFI API is proven stable
 
-### 8.3 Language Bindings
+### 8.3 Language Bindings ✅ COMPLETE
 
 **Goal**: Python and C FFI as the highest-priority non-mobile targets (covers scripting, agent frameworks, and "any other language via C").
 
@@ -1296,12 +1296,14 @@ MinigrafKit-v0.9.0.zip            ← Swift Package Manager checksum source
 
 **Deliverable**: ✅ `implementation("io.github.adityamukho:minigraf-jvm:0.23.0")` — JVM bindings published to Maven Central.
 
-#### 8.3d: Node.js / TypeScript Bindings
+#### 8.3d: Node.js / TypeScript Bindings ✅ COMPLETE
+
+**Status**: ✅ Completed (April 2026) — v0.25.0
 
 **Features**:
 - ✅ 8.3c: C header (`minigraf.h`) via `cbindgen` for any language with a C FFI — v0.24.0 COMPLETE
-- 🎯 8.3d: Node.js / TypeScript bindings via `napi-rs` — v0.25.0
-- 🎯 Published to npm (`@minigraf/core`)
+- ✅ 8.3d: Node.js / TypeScript bindings via `napi-rs` — v0.25.0 COMPLETE
+- ✅ Published to npm (`minigraf`)
 
 **Note**: Python and C bindings share the UniFFI / cbindgen work done for mobile — the incremental cost is small once Phase 8.2 is complete.
 
@@ -1659,7 +1661,7 @@ When evaluating features, ask:
 
 ## Current Focus
 
-**Right Now**: Phase 8.3 In Progress — Language Bindings
+**Right Now**: Phase 8.3 ✅ COMPLETE — Language Bindings
 
 **Phase 8.2 Progress** ✅ COMPLETE:
 1. ✅ Workspace conversion (`minigraf-ffi` crate added)
@@ -1673,10 +1675,10 @@ When evaluating features, ask:
 - ✅ 8.3a: Python bindings via UniFFI — PyPI `minigraf` — v0.22.0 COMPLETE
 - ✅ 8.3b: Desktop JVM bindings — fat JAR on Maven Central (`io.github.adityamukho:minigraf-jvm:0.23.0`) — v0.23.0 COMPLETE
 - ✅ 8.3c: C bindings via `cbindgen` — GitHub Releases tarballs (`minigraf.h` + shared lib) — v0.24.0 COMPLETE
-- 🎯 8.3d: Node.js bindings via `napi-rs` (v0.25.0)
+- ✅ 8.3d: Node.js bindings via `napi-rs` — npm `minigraf` — v0.25.0 COMPLETE
 
-**Immediate Next Steps (Phase 8.3)**:
-1. 8.3d: Node.js bindings via `napi-rs`
+**Immediate Next Steps**:
+- Phase 9: Ecosystem & Tooling
 
 **Key Decisions Made**:
 - ✅ Datalog query language (simpler, better for temporal)
@@ -1692,4 +1694,4 @@ See [GitHub Issues](https://github.com/adityamukho/minigraf/issues) for specific
 
 ---
 
-**Last Updated**: Phase 8.3c Complete (April 2026) — 795 tests passing, v0.24.0
+**Last Updated**: Phase 8.3d Complete (April 2026) — 795 tests passing, v0.25.0

--- a/minigraf-node/Cargo.toml
+++ b/minigraf-node/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "minigraf-node"
+version = "0.25.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi = { version = "2.16", features = ["napi6", "async"] }
+napi-derive = "2.16"
+minigraf = { path = ".." }
+serde_json = "1.0"
+
+[build-dependencies]
+napi-build = "2.1"

--- a/minigraf-node/Cargo.toml
+++ b/minigraf-node/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "2.16", features = ["napi6", "async"] }
+napi = { version = "2.16", features = ["napi6"] }
 napi-derive = "2.16"
 minigraf = { path = ".." }
 serde_json = "1.0"

--- a/minigraf-node/build.rs
+++ b/minigraf-node/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/minigraf-node/index.d.ts
+++ b/minigraf-node/index.d.ts
@@ -1,0 +1,9 @@
+/* tslint:disable */
+/* eslint-disable */
+
+export class MiniGrafDb {
+  constructor(path: string)
+  static inMemory(): MiniGrafDb
+  execute(datalog: string): string
+  checkpoint(): void
+}

--- a/minigraf-node/index.js
+++ b/minigraf-node/index.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const { platform, arch } = process
+
+let nativeBinding = null
+const loadErrors = []
+
+if (platform === 'linux') {
+  if (arch === 'x64') {
+    try { nativeBinding = require('@minigraf/linux-x64-gnu') }
+    catch (e) { loadErrors.push(e) }
+  } else if (arch === 'arm64') {
+    try { nativeBinding = require('@minigraf/linux-arm64-gnu') }
+    catch (e) { loadErrors.push(e) }
+  }
+} else if (platform === 'darwin') {
+  try { nativeBinding = require('@minigraf/darwin-universal') }
+  catch (e) { loadErrors.push(e) }
+} else if (platform === 'win32') {
+  if (arch === 'x64') {
+    try { nativeBinding = require('@minigraf/win32-x64-msvc') }
+    catch (e) { loadErrors.push(e) }
+  }
+}
+
+if (!nativeBinding) {
+  const errorMessages = loadErrors.map(e => e.message).join('\n')
+  throw new Error(
+    `Failed to load native Minigraf addon for ${platform}-${arch}.\n` +
+    `This platform may not be supported yet.\n` +
+    (errorMessages ? `Errors:\n${errorMessages}` : '')
+  )
+}
+
+module.exports = nativeBinding

--- a/minigraf-node/package.json
+++ b/minigraf-node/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/adityamukho/minigraf.git"
   },
   "keywords": ["graph", "datalog", "bitemporal", "embedded", "database"],
+  "engines": {
+    "node": ">=18"
+  },
   "napi": {
     "name": "minigraf",
     "triples": {

--- a/minigraf-node/package.json
+++ b/minigraf-node/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "minigraf",
+  "version": "0.25.0",
+  "description": "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adityamukho/minigraf.git"
+  },
+  "keywords": ["graph", "datalog", "bitemporal", "embedded", "database"],
+  "napi": {
+    "name": "minigraf",
+    "triples": {
+      "defaults": true,
+      "additional": [
+        "aarch64-unknown-linux-gnu",
+        "universal-apple-darwin"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "napi build --platform --release",
+    "test": "node --test test/basic.test.mjs"
+  },
+  "devDependencies": {
+    "@napi-rs/cli": "^2.18.0"
+  },
+  "optionalDependencies": {
+    "@minigraf/linux-x64-gnu": "0.25.0",
+    "@minigraf/linux-arm64-gnu": "0.25.0",
+    "@minigraf/darwin-universal": "0.25.0",
+    "@minigraf/win32-x64-msvc": "0.25.0"
+  }
+}

--- a/minigraf-node/src/lib.rs
+++ b/minigraf-node/src/lib.rs
@@ -28,8 +28,10 @@ fn query_result_to_json(result: QueryResult) -> String {
         QueryResult::Retracted(tx) => serde_json::json!({"retracted": tx}),
         QueryResult::Ok => serde_json::json!({"ok": true}),
         QueryResult::QueryResults { vars, results } => {
-            let rows: Vec<Vec<serde_json::Value>> =
-                results.iter().map(|r| r.iter().map(value_to_json).collect()).collect();
+            let rows: Vec<Vec<serde_json::Value>> = results
+                .iter()
+                .map(|r| r.iter().map(value_to_json).collect())
+                .collect();
             serde_json::json!({"variables": vars, "results": rows})
         }
     };

--- a/minigraf-node/src/lib.rs
+++ b/minigraf-node/src/lib.rs
@@ -1,1 +1,89 @@
-// Implementation in Task 2
+#![deny(clippy::all)]
+
+use minigraf::{QueryResult, Value};
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use std::sync::{Arc, Mutex};
+
+// ─── Value → JSON ─────────────────────────────────────────────────────────────
+
+fn value_to_json(v: &Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    match v {
+        Value::String(s) => J::String(s.clone()),
+        Value::Integer(i) => serde_json::json!(i),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(J::Number)
+            .unwrap_or(J::Null),
+        Value::Boolean(b) => J::Bool(*b),
+        Value::Ref(u) => J::String(u.to_string()),
+        Value::Keyword(k) => J::String(k.clone()),
+        Value::Null => J::Null,
+    }
+}
+
+fn query_result_to_json(result: QueryResult) -> String {
+    let val = match result {
+        QueryResult::Transacted(tx) => serde_json::json!({"transacted": tx}),
+        QueryResult::Retracted(tx) => serde_json::json!({"retracted": tx}),
+        QueryResult::Ok => serde_json::json!({"ok": true}),
+        QueryResult::QueryResults { vars, results } => {
+            let rows: Vec<Vec<serde_json::Value>> =
+                results.iter().map(|r| r.iter().map(value_to_json).collect()).collect();
+            serde_json::json!({"variables": vars, "results": rows})
+        }
+    };
+    val.to_string()
+}
+
+// ─── MiniGrafDb ───────────────────────────────────────────────────────────────
+
+#[napi]
+pub struct MiniGrafDb {
+    inner: Arc<Mutex<minigraf::Minigraf>>,
+}
+
+#[napi]
+impl MiniGrafDb {
+    /// Open a file-backed database. Throws on error.
+    #[napi(constructor)]
+    pub fn new(path: String) -> Result<Self> {
+        let db = minigraf::Minigraf::open(&path)
+            .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(db)),
+        })
+    }
+
+    /// Open an in-memory database. Throws on error.
+    #[napi(factory)]
+    pub fn in_memory() -> Result<Self> {
+        let db = minigraf::Minigraf::in_memory()
+            .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(db)),
+        })
+    }
+
+    /// Execute a Datalog string. Returns a JSON string. Throws on error.
+    #[napi]
+    pub fn execute(&self, datalog: String) -> Result<String> {
+        let result = self
+            .inner
+            .lock()
+            .map_err(|_| Error::new(Status::GenericFailure, "mutex poisoned"))?
+            .execute(&datalog)
+            .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))?;
+        Ok(query_result_to_json(result))
+    }
+
+    /// Flush the WAL to disk. Throws on error.
+    #[napi]
+    pub fn checkpoint(&self) -> Result<()> {
+        self.inner
+            .lock()
+            .map_err(|_| Error::new(Status::GenericFailure, "mutex poisoned"))?
+            .checkpoint()
+            .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))
+    }
+}

--- a/minigraf-node/src/lib.rs
+++ b/minigraf-node/src/lib.rs
@@ -1,0 +1,1 @@
+// Implementation in Task 2

--- a/minigraf-node/test/basic.test.mjs
+++ b/minigraf-node/test/basic.test.mjs
@@ -1,0 +1,49 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { MiniGrafDb } from '../index.js'
+
+test('open in-memory database', () => {
+  const db = MiniGrafDb.inMemory()
+  assert.ok(db, 'expected non-null db')
+})
+
+test('transact and query', () => {
+  const db = MiniGrafDb.inMemory()
+  const txJson = db.execute('(transact [[:alice :name "Alice"]])')
+  const tx = JSON.parse(txJson)
+  assert.ok('transacted' in tx, 'expected transacted key')
+
+  const queryJson = db.execute('(query [:find ?n :where [?e :name ?n]])')
+  const qr = JSON.parse(queryJson)
+  assert.equal(qr.results[0][0], 'Alice')
+})
+
+test('invalid datalog throws', () => {
+  const db = MiniGrafDb.inMemory()
+  assert.throws(() => db.execute('not valid datalog !!!'))
+})
+
+test('file-backed roundtrip', async (t) => {
+  const os = await import('node:os')
+  const path = await import('node:path')
+  const fs = await import('node:fs')
+
+  const tmpDir = os.default.tmpdir()
+  const dbPath = path.default.join(tmpDir, `minigraf_node_test_${Date.now()}.graph`)
+  const walPath = dbPath + '.wal'
+
+  t.after(() => {
+    try { fs.default.unlinkSync(dbPath) } catch {}
+    try { fs.default.unlinkSync(walPath) } catch {}
+  })
+
+  {
+    const db = new MiniGrafDb(dbPath)
+    db.execute('(transact [[:bob :name "Bob"]])')
+    db.checkpoint()
+  }
+
+  const db2 = new MiniGrafDb(dbPath)
+  const qr = JSON.parse(db2.execute('(query [:find ?n :where [?e :name ?n]])'))
+  assert.equal(qr.results[0][0], 'Bob')
+})


### PR DESCRIPTION
## Summary

- Adds `minigraf-node` workspace crate using `napi-rs` to expose `MiniGrafDb` to Node.js
- Publishes `minigraf` to npm with prebuilt `.node` binaries for Linux x86_64/aarch64, macOS universal2, Windows x86_64 — no build step required for consumers
- Full TypeScript definitions (`index.d.ts`) included; API: `new MiniGrafDb(path)`, `MiniGrafDb.inMemory()`, `.execute(datalog)`, `.checkpoint()`

## Changes

- `minigraf-node/` — new napi-rs cdylib crate (`Cargo.toml`, `build.rs`, `src/lib.rs`)
- `minigraf-node/package.json`, `index.js`, `index.d.ts` — npm package distribution files
- `minigraf-node/test/basic.test.mjs` — node:test suite (in-memory, transact/query, error, file roundtrip)
- `.github/workflows/node-ci.yml` — PR test matrix (4 platforms)
- `.github/workflows/node-release.yml` — build `.node` binaries + publish to npm
- `release.yml` — wired `publish-node` job alongside existing `publish-python` and `publish-c`
- Version bumped to `0.25.0`; CHANGELOG and ROADMAP updated

## Test Plan

- [ ] CI passes on all 4 platforms (ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest)
- [ ] `cargo check --workspace` passes locally
- [ ] `node-ci.yml` builds addon and runs `node --test` suite on each platform
- [ ] CHANGELOG entry present for v0.25.0
- [ ] ROADMAP marks Phase 8.3d and Phase 8.3 as ✅ COMPLETE

🤖 Generated with [Claude Code](https://claude.com/claude-code)