### PR TITLE
docs: add language binding usage examples (Python, Node.js, Java, C)

### DIFF
--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -1,0 +1,32 @@
+#include "minigraf.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    MiniGrafDb *db = minigraf_open_in_memory();
+    if (!db) {
+        fprintf(stderr, "failed to open database\n");
+        return 1;
+    }
+
+    char *result = minigraf_execute(db, "(transact [[:alice :name \"Alice\"] [:alice :age 30]])");
+    if (!result) {
+        fprintf(stderr, "transact error: %s\n", minigraf_last_error(db));
+        minigraf_close(db);
+        return 1;
+    }
+    minigraf_string_free(result);
+
+    char *query = minigraf_execute(db, "(query [:find ?e ?name :where [?e :name ?name]])");
+    if (!query) {
+        fprintf(stderr, "query error: %s\n", minigraf_last_error(db));
+        minigraf_close(db);
+        return 1;
+    }
+    printf("%s\n", query);
+    minigraf_string_free(query);
+
+    minigraf_checkpoint(db);
+    minigraf_close(db);
+    return 0;
+}

--- a/examples/java/Example.java
+++ b/examples/java/Example.java
@@ -1,0 +1,15 @@
+import uniffi.minigraf_ffi.MiniGrafDb;
+
+public class Example {
+    public static void main(String[] args) {
+        MiniGrafDb db = MiniGrafDb.openInMemory();
+
+        db.execute("(transact [[:alice :name \"Alice\"] [:alice :age 30]])");
+
+        String result = db.execute("(query [:find ?e ?name :where [?e :name ?name]])");
+        System.out.println(result);
+
+        db.checkpoint();
+        db.destroy();
+    }
+}

--- a/examples/node/example.js
+++ b/examples/node/example.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { MiniGrafDb } = require('minigraf')
+
+const db = MiniGrafDb.inMemory()
+
+db.execute('(transact [[:alice :name "Alice"] [:alice :age 30]])')
+
+const result = JSON.parse(db.execute('(query [:find ?e ?name :where [?e :name ?name]])'))
+console.log(result)
+
+db.checkpoint()

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -1,0 +1,11 @@
+from minigraf import MiniGrafDb
+
+db = MiniGrafDb.open_in_memory()
+
+db.execute('(transact [[:alice :name "Alice"] [:alice :age 30]])')
+
+result = db.execute("(query [:find ?e ?name :where [?e :name ?name]])")
+import json
+print(json.loads(result))
+
+db.checkpoint()


### PR DESCRIPTION
## Summary

- Adds `examples/python/example.py` — open in-memory db, transact, query, checkpoint
- Adds `examples/node/example.js` — same flow via the npm `minigraf` package
- Adds `examples/java/Example.java` — same flow via the Maven `minigraf-jvm` JAR
- Adds `examples/c/example.c` — same flow via the C FFI (`minigraf.h`)

Closes #132

## Test Plan
- [ ] CI passes
🤖 Generated with [Claude Code](https://claude.com/claude-code)