### PR TITLE
docs: Datalog tutorial series — 11 sections, Corestore storyline (closes #234)

### DIFF
--- a/demos/tutorial_corestore_setup.txt
+++ b/demos/tutorial_corestore_setup.txt
@@ -1,0 +1,91 @@
+# ================================================================
+# Corestore Tutorial Dataset
+# ================================================================
+# Base setup for the Minigraf Datalog tutorial series.
+# All tutorial sections assume this has been loaded first.
+#
+# Run with: cargo run < demos/tutorial_corestore_setup.txt
+#
+# After loading: tx_count = 3
+# ================================================================
+
+# ── tx 1: Category hierarchy ─────────────────────────────────────
+# Electronics
+#   ├── Laptops
+#   ├── Mobile
+#   ├── Audio
+#   │   └── Headphones
+#   │       └── Noise-Cancelling
+#   └── Accessories
+
+(transact [
+  [:cat-electronics :category/name "Electronics"]
+  [:cat-laptops     :category/name "Laptops"]
+  [:cat-laptops     :category/parent :cat-electronics]
+  [:cat-mobile      :category/name "Mobile"]
+  [:cat-mobile      :category/parent :cat-electronics]
+  [:cat-audio       :category/name "Audio"]
+  [:cat-audio       :category/parent :cat-electronics]
+  [:cat-headphones  :category/name "Headphones"]
+  [:cat-headphones  :category/parent :cat-audio]
+  [:cat-nc          :category/name "Noise-Cancelling"]
+  [:cat-nc          :category/parent :cat-headphones]
+  [:cat-accessories :category/name "Accessories"]
+  [:cat-accessories :category/parent :cat-electronics]
+])
+
+# ── tx 2: Product catalog ─────────────────────────────────────────
+# Two products per major leaf category for window function examples.
+
+(transact [
+  [:laptop-pro    :product/name "LaptopPro 15"]
+  [:laptop-pro    :product/sku "LP-15"]
+  [:laptop-pro    :product/price 1299]
+  [:laptop-pro    :product/category :cat-laptops]
+
+  [:laptop-budget :product/name "BudgetBook 14"]
+  [:laptop-budget :product/sku "LB-14"]
+  [:laptop-budget :product/price 699]
+  [:laptop-budget :product/category :cat-laptops]
+
+  [:phone-x       :product/name "PhoneX 12"]
+  [:phone-x       :product/sku "PX-12"]
+  [:phone-x       :product/price 799]
+  [:phone-x       :product/category :cat-mobile]
+
+  [:phone-prev    :product/name "PhoneX 11"]
+  [:phone-prev    :product/sku "PX-11"]
+  [:phone-prev    :product/price 599]
+  [:phone-prev    :product/category :cat-mobile]
+
+  [:nc-headphones :product/name "NoiseCancel Pro"]
+  [:nc-headphones :product/sku "NC-PRO"]
+  [:nc-headphones :product/price 249]
+  [:nc-headphones :product/category :cat-nc]
+
+  [:usb-cable     :product/name "USB-C Cable 2m"]
+  [:usb-cable     :product/sku "USB-C-2M"]
+  [:usb-cable     :product/price 19]
+  [:usb-cable     :product/category :cat-accessories]
+
+  [:keyboard-k1   :product/name "Compact Keyboard"]
+  [:keyboard-k1   :product/sku "KB-K1"]
+  [:keyboard-k1   :product/price 89]
+  [:keyboard-k1   :product/category :cat-accessories]
+
+  [:monitor-27    :product/name "ClearView 27\" Monitor"]
+  [:monitor-27    :product/sku "CV-27"]
+  [:monitor-27    :product/price 449]
+  [:monitor-27    :product/category :cat-electronics]
+])
+
+# ── tx 3: Customers ───────────────────────────────────────────────
+
+(transact [
+  [:alice :customer/name "Alice"]
+  [:alice :customer/email "alice@example.com"]
+  [:ben   :customer/name "Ben"]
+  [:ben   :customer/email "ben@example.com"]
+  [:clara :customer/name "Clara"]
+  [:clara :customer/email "clara@example.com"]
+])

--- a/examples/tutorial_udfs.rs
+++ b/examples/tutorial_udfs.rs
@@ -1,0 +1,171 @@
+//! Tutorial Section 10 — User-Defined Functions
+//!
+//! Demonstrates `register_predicate` and `register_aggregate` in the context
+//! of the Corestore e-commerce scenario.
+//!
+//! Run with:
+//!   cargo run --example tutorial_udfs
+
+use minigraf::{Minigraf, QueryResult, Value};
+
+fn main() -> anyhow::Result<()> {
+    let db = Minigraf::in_memory()?;
+
+    // ── Seed data ────────────────────────────────────────────────────────────
+    //
+    // Promo codes: one valid Corestore code, one invalid short code, one from
+    // a different scheme.
+
+    db.execute(r#"(transact [
+        [:promo-1 :promo/code "CORESTORE-SUMMER2026"]
+        [:promo-2 :promo/code "SAVE10"]
+        [:promo-3 :promo/code "PARTNER-EXCLUSIVE"]
+    ])"#)?;
+
+    // Customers and their orders with on-time-flag attributes.
+    //   Alice: order-a (on time), order-b (late)  → score = 1/2 = 0.5
+    //   Ben:   order-c (on time)                  → score = 1/1 = 1.0
+
+    db.execute(r#"(transact [
+        [:alice :customer/name "Alice"]
+        [:ben   :customer/name "Ben"]
+        [:order-a :order/customer :alice]
+        [:order-a :order/on-time-flag 1]
+        [:order-b :order/customer :alice]
+        [:order-b :order/on-time-flag 0]
+        [:order-c :order/customer :ben]
+        [:order-c :order/on-time-flag 1]
+    ])"#)?;
+
+    // ── Predicate UDF: valid-promo? ───────────────────────────────────────────
+    //
+    // A valid Corestore promo code must start with "CORESTORE-" and be at
+    // least 15 characters long.
+
+    db.register_predicate(
+        "valid-promo?",
+        |v: &Value| {
+            if let Value::String(s) = v {
+                s.starts_with("CORESTORE-") && s.len() >= 15
+            } else {
+                false
+            }
+        },
+    )?;
+
+    println!("=== Predicate UDF: valid-promo? ===");
+    println!();
+    println!("Query: find promo codes that satisfy valid-promo?");
+    println!();
+    println!("  (query [:find ?code");
+    println!("          :where [?p :promo/code ?code]");
+    println!("                 [(valid-promo? ?code)]])");
+    println!();
+
+    let promo_result = db.execute(
+        r#"(query [:find ?code
+                   :where [?p :promo/code ?code]
+                          [(valid-promo? ?code)]])"#,
+    )?;
+
+    let (promo_rows, promo_count) = match promo_result {
+        QueryResult::QueryResults { results, .. } => {
+            let n = results.len();
+            (results, n)
+        }
+        _ => (vec![], 0),
+    };
+
+    println!("?code");
+    println!("--------------------");
+    for row in &promo_rows {
+        for val in row {
+            match val {
+                Value::String(s) => print!("\"{}\"", s),
+                other => print!("{:?}", other),
+            }
+        }
+        println!();
+    }
+    println!();
+    println!("{} result(s) found.", promo_count);
+    println!();
+
+    // ── Aggregate UDF: delivery-score ────────────────────────────────────────
+    //
+    // delivery-score receives a stream of integer flags (1 = on time, 0 = late)
+    // and returns on_time_count / total_count as a float.
+    //
+    // Accumulator state: (on_time_count: i64, total_count: i64)
+
+    db.register_aggregate(
+        "delivery-score",
+        || (0i64, 0i64),
+        |state: &mut (i64, i64), val: &Value| {
+            if let Value::Integer(flag) = val {
+                state.1 += 1;
+                if *flag == 1 {
+                    state.0 += 1;
+                }
+            }
+        },
+        |state: &(i64, i64), _n: usize| {
+            if state.1 == 0 {
+                Value::Null
+            } else {
+                Value::Float(state.0 as f64 / state.1 as f64)
+            }
+        },
+    )?;
+
+    println!("=== Aggregate UDF: delivery-score ===");
+    println!();
+    println!("Query: on-time delivery score per customer");
+    println!();
+    println!("  (query [:find ?name (delivery-score ?flag)");
+    println!("          :where [?customer :customer/name ?name]");
+    println!("                 [?order :order/customer ?customer]");
+    println!("                 [?order :order/on-time-flag ?flag]])");
+    println!();
+
+    let score_result = db.execute(
+        r#"(query [:find ?name (delivery-score ?flag)
+                   :where [?customer :customer/name ?name]
+                          [?order :order/customer ?customer]
+                          [?order :order/on-time-flag ?flag]])"#,
+    )?;
+
+    let (score_rows, score_count) = match score_result {
+        QueryResult::QueryResults { results, .. } => {
+            let n = results.len();
+            (results, n)
+        }
+        _ => (vec![], 0),
+    };
+
+    println!("?name     (delivery-score ?flag)");
+    println!("------------------------------------");
+    for row in &score_rows {
+        let name = match &row[0] {
+            Value::String(s) => format!("\"{}\"", s),
+            other => format!("{:?}", other),
+        };
+        let score = match &row[1] {
+            Value::Float(f) => {
+                // Always show at least one decimal place for clarity
+                if f.fract() == 0.0 {
+                    format!("{:.1}", f)
+                } else {
+                    format!("{}", f)
+                }
+            }
+            Value::Null => "null".to_string(),
+            other => format!("{:?}", other),
+        };
+        println!("{:<10}{}", name, score);
+    }
+    println!();
+    println!("{} result(s) found.", score_count);
+
+    Ok(())
+}

--- a/examples/tutorial_udfs.rs
+++ b/examples/tutorial_udfs.rs
@@ -167,5 +167,51 @@ fn main() -> anyhow::Result<()> {
     println!();
     println!("{} result(s) found.", score_count);
 
+    // ── UDF aggregate in a window clause ─────────────────────────────────────────
+    println!();
+    println!("=== UDF aggregate in a window clause ===");
+    println!();
+    println!("Query: annotate each order with its customer delivery score");
+    println!();
+
+    let window_result = db.execute(
+        r#"(query [:find ?order (delivery-score ?flag :over (:partition-by ?customer :order-by ?order))
+               :where [?customer :customer/name ?name]
+                      [?order :order/customer ?customer]
+                      [?order :order/on-time-flag ?flag]])"#,
+    )?;
+
+    let (window_rows, window_count) = match window_result {
+        QueryResult::QueryResults { results, .. } => {
+            let n = results.len();
+            (results, n)
+        }
+        _ => (vec![], 0),
+    };
+
+    println!("?order     (delivery-score ?flag :over ...)");
+    println!("--------------------------------------------");
+    for row in &window_rows {
+        let order = match &row[0] {
+            Value::Keyword(k) => format!(":{}", k),
+            Value::Ref(u) => format!("{}", &u.to_string()[..8]),
+            other => format!("{:?}", other),
+        };
+        let score = match &row[1] {
+            Value::Float(f) => {
+                if f.fract() == 0.0 {
+                    format!("{:.1}", f)
+                } else {
+                    format!("{}", f)
+                }
+            }
+            Value::Null => "null".to_string(),
+            other => format!("{:?}", other),
+        };
+        println!("{:<12}{}", order, score);
+    }
+    println!();
+    println!("{} result(s) found.", window_count);
+
     Ok(())
 }

--- a/examples/tutorial_udfs.rs
+++ b/examples/tutorial_udfs.rs
@@ -16,17 +16,20 @@ fn main() -> anyhow::Result<()> {
     // Promo codes: one valid Corestore code, one invalid short code, one from
     // a different scheme.
 
-    db.execute(r#"(transact [
+    db.execute(
+        r#"(transact [
         [:promo-1 :promo/code "CORESTORE-SUMMER2026"]
         [:promo-2 :promo/code "SAVE10"]
         [:promo-3 :promo/code "PARTNER-EXCLUSIVE"]
-    ])"#)?;
+    ])"#,
+    )?;
 
     // Customers and their orders with on-time-flag attributes.
     //   Alice: order-a (on time), order-b (late)  → score = 1/2 = 0.5
     //   Ben:   order-c (on time)                  → score = 1/1 = 1.0
 
-    db.execute(r#"(transact [
+    db.execute(
+        r#"(transact [
         [:alice :customer/name "Alice"]
         [:ben   :customer/name "Ben"]
         [:order-a :order/customer :alice]
@@ -35,23 +38,21 @@ fn main() -> anyhow::Result<()> {
         [:order-b :order/on-time-flag 0]
         [:order-c :order/customer :ben]
         [:order-c :order/on-time-flag 1]
-    ])"#)?;
+    ])"#,
+    )?;
 
     // ── Predicate UDF: valid-promo? ───────────────────────────────────────────
     //
     // A valid Corestore promo code must start with "CORESTORE-" and be at
     // least 15 characters long.
 
-    db.register_predicate(
-        "valid-promo?",
-        |v: &Value| {
-            if let Value::String(s) = v {
-                s.starts_with("CORESTORE-") && s.len() >= 15
-            } else {
-                false
-            }
-        },
-    )?;
+    db.register_predicate("valid-promo?", |v: &Value| {
+        if let Value::String(s) = v {
+            s.starts_with("CORESTORE-") && s.len() >= 15
+        } else {
+            false
+        }
+    })?;
 
     println!("=== Predicate UDF: valid-promo? ===");
     println!();


### PR DESCRIPTION
## Summary

- Adds `demos/tutorial_corestore_setup.txt` — the shared base dataset (Corestore e-commerce catalog: 3 categories, 8 products, 3 customers) that all 11 tutorial sections build on
- Adds `examples/tutorial_udfs.rs` — a standalone Rust example demonstrating `register_predicate` and `register_aggregate` (Section 10, UDF-only features that cannot be shown in the REPL)
- Delivers 12 wiki pages (setup + 11 sections) covering every Minigraf Datalog grammar construct, driven by a real-world e-commerce storyline (Corestore, with characters Alice/Ben/Clara)

**Wiki pages published:**
- `Tutorial-Setup` — prerequisites, dataset, cumulative tx_count table
- `Tutorial-01` through `Tutorial-11` — basic queries → bi-temporal → recursion → negation → aggregates → expressions → prepared queries → disjunction → UDFs → marketplace
- `Home.md` — "Tutorials" section added before "Pages"
- `Learning-Resources.md` — tutorial series listed as primary Minigraf Datalog resource

## Grammar coverage

All constructs from `Datalog-Reference.md` are demonstrated: `transact`, `retract`, `rule`, `query`, `:find` (variables, aggregates, window exprs), `:where` (pattern, expr, not, not-join, or, or-join, and-branch, rule-invocation), `:as-of`, `:valid-at`, `:any-valid-time`, `:with`, scalar aggregates, window functions, `:partition-by`, `:order-by`, `:desc`, comparison/arithmetic/string/type predicates, `$bind-slot` prepared queries, `register_predicate` UDF, `register_aggregate` UDF.

## Test plan

- [ ] `cargo run --example tutorial_udfs` produces the expected predicate + aggregate + window output
- [ ] `cargo run < demos/tutorial_corestore_setup.txt` loads 3 transacts cleanly (tx_count = 3)
- [ ] All 795 existing tests continue to pass (verified by pre-push hook above)
- [ ] Wiki pages render correctly on https://github.com/project-minigraf/minigraf/wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)