### PR TITLE
fix: treat ';' as a comment character in the REPL

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -255,7 +255,10 @@ mod tests {
     fn comment_and_blank_lines_are_skipped() {
         let db = Minigraf::in_memory().expect("in-memory db");
         let repl = db.repl();
-        repl.run_impl(std::io::Cursor::new(b"# hash comment\n; edn comment\n\nEXIT\n"), false);
+        repl.run_impl(
+            std::io::Cursor::new(b"# hash comment\n; edn comment\n\nEXIT\n"),
+            false,
+        );
     }
 
     #[test]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -85,7 +85,7 @@ impl<'a> Repl<'a> {
 
                     let line = input.trim();
 
-                    if line.is_empty() || line.starts_with('#') {
+                    if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
                         continue;
                     }
 
@@ -255,7 +255,7 @@ mod tests {
     fn comment_and_blank_lines_are_skipped() {
         let db = Minigraf::in_memory().expect("in-memory db");
         let repl = db.repl();
-        repl.run_impl(std::io::Cursor::new(b"# comment\n\nEXIT\n"), false);
+        repl.run_impl(std::io::Cursor::new(b"# hash comment\n; edn comment\n\nEXIT\n"), false);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- EDN uses `;` for line comments; the REPL only recognised `#`.
- A line starting with `;` (after trimming) is now skipped alongside `#` and blank lines.
- Demo files and tutorial scripts that use EDN-style comments (e.g. `; A fact is a triple`) are now handled correctly instead of producing a parse error.

## Test plan

- [x] Existing `comment_and_blank_lines_are_skipped` test extended to include a `;` comment line — passes.
- [x] All 800 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)