### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.0 — 2026-05-17
+
+Drop-in replacement for v1.0.0. No file-format changes, no public API changes, no query surface changes. Upgrading requires no code changes.
+
+### Performance
+
+- Hash-join replaces nested-loop join for multi-clause queries — O(N) instead of O(N²) for large fact sets (#202, #203, #204)
+- Selective B+Tree fact fetch: queries with bound entity/attribute skip full-scan and read only relevant index pages (#208)
+- Predicate push-down into join ordering (#207)
+- Cost-based clause ordering for `not`/`or` rules (#206, #205)
+- SIMD crossover analysis and benchmarking infrastructure (#229)
+
+### Bug fixes
+
+- Fixed critical correctness and durability bugs found during deep audit (#225): fact visibility edge cases, WAL entry ordering, checkpoint atomicity
+- Fixed read-only handle `Drop` triggering unnecessary checkpoint, modifying the file on close (#226)
+- `QueryResult::Transacted` and `Retracted` reverted to tuple variants — struct-variant form introduced post-1.0 was a breaking change (#261)
+- Added `Minigraf::current_tx_count() -> u64` as additive API to expose the `:as-of` monotonic counter without breaking existing pattern matches
+
+### Reliability & testing
+
+- WAL fault injection harness (`FaultInjectingBackend`) with 9 crash-recovery tests (#209, #210, #214)
+- Storage/migration resilience: migration matrix, index corruption recovery, concurrency stress tests (#215, #216, #217)
+- Property-based query correctness tests against a reference evaluator (proptest, #212)
+- Datalog parser/evaluator fuzz targets with seed corpus (#213)
+- Per-module branch coverage gates in CI (#219)
+- Long-haul smoke suite: 500 entities × 10 write/read/checkpoint cycles (#220)
+- XTDB and Datomic semantic compatibility tests (#221)
+
+### Internal
+
+- Workspace-wide clippy lint enforcement — 336 violations fixed (#232)
+- Grammar conformance test harness: pest shadow grammar + EDN corpus (#233)
+- CI: codecov-action v3→v5, actions-rs→dtolnay migration
+
 ## Wave 3 Reliability — 2026-05-17
 
 ### Summary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "minigraf"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://codecov.io/gh/project-minigraf/minigraf/branch/main/graph/badge.svg)](https://codecov.io/gh/project-minigraf/minigraf)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/project-minigraf/minigraf#license)
 [![Rust Edition](https://img.shields.io/badge/rust-2024-orange.svg)](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html)
-[![Release](https://img.shields.io/badge/release-v1.0.0-blue.svg)](https://github.com/project-minigraf/minigraf/releases/tag/v1.0.0)
+[![Release](https://img.shields.io/badge/release-v1.1.0-blue.svg)](https://github.com/project-minigraf/minigraf/releases/tag/v1.1.0)
 
 > **Embedded graph memory for AI agents, mobile apps, and the browser** — the SQLite of bi-temporal graph databases
 

--- a/minigraf-c/Cargo.toml
+++ b/minigraf-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-c"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "C bindings for Minigraf — stable C API with cbindgen-generated header"
 publish = false

--- a/minigraf-ffi/Cargo.toml
+++ b/minigraf-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-ffi"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "UniFFI mobile bindings for Minigraf (Android + iOS)"
 publish = false

--- a/minigraf-ffi/python/pyproject.toml
+++ b/minigraf-ffi/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "minigraf"
-version = "1.0.0"
+version = "1.1.0"
 description = "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries"
 license = { text = "MIT OR Apache-2.0" }
 requires-python = ">=3.9"

--- a/minigraf-node/Cargo.toml
+++ b/minigraf-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-node"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 publish = false
 

--- a/minigraf-node/package.json
+++ b/minigraf-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minigraf",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## v1.1.0 — drop-in replacement for v1.0.0

No file-format changes, no public API changes, no query surface changes.

### What's in this release

**Performance**
- Hash-join replaces nested-loop join (O(N) vs O(N²)) — #202, #203, #204
- Selective B+Tree fact fetch for bound entity/attribute queries — #208
- Predicate push-down, cost-based `not`/`or` ordering — #205, #206, #207
- SIMD benchmarking infrastructure — #229

**Bug fixes**
- Critical correctness/durability bugs from deep audit — #225
- Read-only handle `Drop` no longer modifies the file — #226
- `QueryResult::Transacted`/`Retracted` restored to tuple variants (was a breaking change) — #261
- New additive `Minigraf::current_tx_count() -> u64` exposes `:as-of` counter

**Reliability**
- WAL fault injection + crash-recovery matrix — #209, #210, #214
- Storage/migration resilience, index corruption recovery — #215, #216, #217
- Property-based query correctness, fuzz targets, coverage gates — #212, #213, #219
- Long-haul smoke suite, XTDB/Datomic compat — #220, #221
- Clippy enforcement (336 violations fixed), grammar conformance harness — #232, #233

## Test plan
- [x] 935 tests passing locally
- [x] Pre-push hooks (fmt + clippy + test) green
- [ ] CI green → merge → tag v1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)