### PR TITLE
chore: release v1.1.1 — fix cargo-dist Windows build failure (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.1 — 2026-05-17
+
+Patch release. Fixes cargo-dist Windows build failure that prevented REPL binaries and crates.io publish from completing for v1.1.0. No code changes to the library itself.
+
+### Build
+
+- Exclude `fuzz` crate from workspace so cargo-dist can build on Windows (MSVC linker incompatible with `#![no_main]` libFuzzer targets) — fixes #263
+
 ## v1.1.0 — 2026-05-17
 
 Drop-in replacement for v1.0.0. No file-format changes, no public API changes, no query surface changes. Upgrading requires no code changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
-members = [".", "minigraf-ffi", "minigraf-c", "minigraf-node", "fuzz"]
+members = [".", "minigraf-ffi", "minigraf-c", "minigraf-node"]
+exclude = ["fuzz"]
 resolver = "2"
 
 [package]
 name = "minigraf"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 description = "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://codecov.io/gh/project-minigraf/minigraf/branch/main/graph/badge.svg)](https://codecov.io/gh/project-minigraf/minigraf)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/project-minigraf/minigraf#license)
 [![Rust Edition](https://img.shields.io/badge/rust-2024-orange.svg)](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html)
-[![Release](https://img.shields.io/badge/release-v1.1.0-blue.svg)](https://github.com/project-minigraf/minigraf/releases/tag/v1.1.0)
+[![Release](https://img.shields.io/badge/release-v1.1.1-blue.svg)](https://github.com/project-minigraf/minigraf/releases/tag/v1.1.1)
 
 > **Embedded graph memory for AI agents, mobile apps, and the browser** — the SQLite of bi-temporal graph databases
 

--- a/minigraf-c/Cargo.toml
+++ b/minigraf-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-c"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 description = "C bindings for Minigraf — stable C API with cbindgen-generated header"
 publish = false

--- a/minigraf-ffi/Cargo.toml
+++ b/minigraf-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-ffi"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 description = "UniFFI mobile bindings for Minigraf (Android + iOS)"
 publish = false

--- a/minigraf-ffi/python/pyproject.toml
+++ b/minigraf-ffi/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "minigraf"
-version = "1.1.0"
+version = "1.1.1"
 description = "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries"
 license = { text = "MIT OR Apache-2.0" }
 requires-python = ">=3.9"

--- a/minigraf-node/Cargo.toml
+++ b/minigraf-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-node"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 publish = false
 

--- a/minigraf-node/package.json
+++ b/minigraf-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minigraf",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Zero-config, single-file, embedded graph database with bi-temporal Datalog queries",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

- Moves `fuzz` crate from workspace `members` to `exclude` so cargo-dist can build on Windows
- MSVC linker raises `LNK1561` on `#![no_main]` libFuzzer targets; `fuzz` is never part of a release build and must be excluded
- This was the root cause of the v1.1.0 cargo-dist failure: crates.io stuck at v1.0.0, 14 REPL/manifest artifacts missing from the GitHub release
- Fixes #263

No library code changes. v1.1.1 is identical to v1.1.0 at the source level.

## Test Plan

- [x] `cargo check --workspace` passes with fuzz excluded
- [x] Pre-push hook: `cargo fmt`, `cargo clippy`, `cargo test` — all green (935 tests)
- [ ] cargo-dist `release.yml` completes on all platforms after merge and tag