### PR TITLE
fix(ffi): add lib crate-type to minigraf-ffi; bump to 1.1.2

### DIFF
--- a/.github/workflows/publish-ffi.yml
+++ b/.github/workflows/publish-ffi.yml
@@ -1,0 +1,23 @@
+name: Publish minigraf-ffi
+
+# Triggered by a tag like ffi-v1.1.2 to publish only minigraf-ffi to crates.io.
+# Used for patch releases that fix the FFI crate independently of the core.
+on:
+  push:
+    tags:
+      - "ffi-v*"
+
+jobs:
+  publish:
+    name: cargo publish minigraf-ffi
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish minigraf-ffi
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p minigraf-ffi

--- a/minigraf-ffi/Cargo.toml
+++ b/minigraf-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minigraf-ffi"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 description = "UniFFI bridge for Minigraf — bi-temporal graph database"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["graph", "datalog", "bitemporal", "embedded", "database"]
 categories = ["database-implementations", "embedded"]
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 
 [[bin]]
 name = "uniffi-bindgen"


### PR DESCRIPTION
## Summary
- Adds `"lib"` to `minigraf-ffi`'s `crate-type` list (was `["cdylib", "staticlib"]`, now `["cdylib", "staticlib", "lib"]`)
- Bumps `minigraf-ffi` version from 1.1.1 → 1.1.2
- Adds `.github/workflows/publish-ffi.yml` — a `ffi-v*` tag-triggered workflow for future FFI-only patch releases

## Root Cause

The `minigraf-python` (and `minigraf-node`/`minigraf-wasm`) binding repos need to create their own `cdylib` that re-exports from `minigraf-ffi` to give maturin a `[lib]` target. This requires `minigraf-ffi` to be usable as a Rust library dependency — which means Cargo must produce an `.rlib` for it.

Without `"lib"` in `crate-type`, Cargo only builds `.so` and `.a` artifacts and never passes `--extern minigraf_ffi=...` when compiling dependents, making `use minigraf_ffi::*` impossible.

## Test Plan
- [x] `cargo build -p minigraf-ffi` succeeds
- [x] All 962 tests pass (pre-push hook)
- [ ] After merge: push `ffi-v1.1.2` tag to publish to crates.io
- [ ] Update `minigraf-python` to depend on `minigraf-ffi = "1.1.2"` and verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)