### PR TITLE
fix(ci): narrow cascade.yml tag pattern to v* only

### DIFF
--- a/.github/workflows/cascade.yml
+++ b/.github/workflows/cascade.yml
@@ -3,7 +3,7 @@ name: Release Cascade
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   publish-ffi:


### PR DESCRIPTION
## Summary
- Changes cascade.yml trigger from `'**[0-9]+.[0-9]+.[0-9]+*'` to `'v[0-9]*.[0-9]*.[0-9]*'`

## Problem
The old pattern matched `ffi-v1.1.2`, causing cascade to fire on the ffi tag and time out waiting for `minigraf@ffi-v1.1.2` on crates.io (which doesn't exist — only `minigraf-ffi` was bumped, not core).

The new pattern matches only `v1.2.3`-style tags (core releases) and excludes `ffi-v*`, `node-v*`, and any other crate-specific tag prefixes.

## Test Plan
- [x] `ffi-v1.1.2` was the incident that revealed this — cascade fired, waited 3 min, failed harmlessly
- [ ] Verify next core release tag (`v1.x.x`) triggers cascade correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)