### PR TITLE
fix(ci): narrow tag patterns to v* in all release workflows

### DIFF
--- a/.github/workflows/c-release.yml
+++ b/.github/workflows/c-release.yml
@@ -3,7 +3,7 @@ name: C Release
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,7 +3,7 @@ name: Docs Check
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -3,7 +3,7 @@ name: Java Release
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -3,7 +3,7 @@ name: Mobile Release Artifacts
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary
Fixes `c-release.yml`, `java-release.yml`, `mobile.yml`, and `docs-check.yml` — all had the same broad tag pattern as cascade (#267 fixed cascade).

## Problem
`ffi-v1.1.2` triggered all four workflows. C Release and Mobile both spent ~10 minutes polling for a GitHub Release that cargo-dist never created (it failed immediately on tag parse). Java Release and Docs Check completed but shouldn't have run at all.

## Pattern change
`'**[0-9]+.[0-9]+.[0-9]+*'` → `'v[0-9]*.[0-9]*.[0-9]*'`

`release.yml` (cargo-dist-owned) is intentionally left alone — it already fails fast and cleanly on non-`v*` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)