### PR TITLE
ci: fix cargo-fuzz install failure on nightly (rustix compat)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,7 @@ jobs:
           key: cargo-fuzz-${{ runner.os }}-${{ hashFiles('fuzz/Cargo.toml') }}
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo install cargo-fuzz
 
       - name: Fuzz wal_entry (60s)
         run: cargo fuzz run wal_entry -- -max_total_time=60


### PR DESCRIPTION
## Summary

- `cargo-fuzz v0.13.1` with `--locked` pulls in an old `rustix` that uses internal `rustc_layout_scalar_valid_range_*` attributes now restricted in recent nightly builds
- Removing `--locked` lets cargo resolve a newer `rustix` without those internal attributes

## Root cause

```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
error: cannot find attribute `rustc_layout_scalar_valid_range_start` in this scope
error: cannot find attribute `rustc_layout_scalar_valid_range_end` in this scope
error: could not compile `rustix` (lib) due to 4 previous errors
```

## Test plan
- [ ] Trigger the Fuzz workflow manually after merge to verify the install step passes
- [ ] Confirm all 6 fuzz targets run to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)