### PR TITLE
perf: fix backend mutex serialisation in CommittedFactLoaderImpl::resolve (#252)

### DIFF
--- a/src/storage/btree_v6.rs
+++ b/src/storage/btree_v6.rs
@@ -586,14 +586,12 @@ where
 /// Read-only [`StorageBackend`] adapter that locks `Arc<Mutex<B>>` only for the
 /// duration of a single [`StorageBackend::read_page`] call.
 ///
-/// Used exclusively by [`OnDiskIndexReader::range_scan_*`] so that the backend
-/// mutex is held only while reading one cold page from disk, rather than for the
-/// entire range scan. On a cache hit [`PageCache::get_or_load`] never calls
-/// `read_page`, so no lock is acquired at all. All methods other than `read_page`
-/// are unimplemented and will panic if called.
-// Instantiated inside OnDiskIndexReader::range_scan_* methods.
-#[allow(dead_code)]
-struct MutexStorageBackend<B>(Arc<Mutex<B>>);
+/// Used by [`OnDiskIndexReader::range_scan_*`] and [`crate::storage::persistent_facts`]
+/// so that the backend mutex is held only while reading one cold page from disk,
+/// rather than for the entire operation. On a cache hit [`PageCache::get_or_load`]
+/// never calls `read_page`, so no lock is acquired at all. All methods other than
+/// `read_page` are unimplemented and will panic if called.
+pub(crate) struct MutexStorageBackend<B>(pub(crate) Arc<Mutex<B>>);
 
 impl<B: StorageBackend> StorageBackend for MutexStorageBackend<B> {
     fn read_page(&self, page_id: u64) -> anyhow::Result<Vec<u8>> {

--- a/src/storage/persistent_facts.rs
+++ b/src/storage/persistent_facts.rs
@@ -7,7 +7,8 @@ use crate::graph::types::Fact;
 use crate::storage::FACT_PAGE_FORMAT_PACKED;
 use crate::storage::btree::{read_aevt_index, read_avet_index, read_eavt_index, read_vaet_index};
 use crate::storage::btree_v6::{
-    OnDiskIndexReader, btree_entries, build_btree, merge_sorted_vecs, stream_all_entries,
+    MutexStorageBackend, OnDiskIndexReader, btree_entries, build_btree, merge_sorted_vecs,
+    stream_all_entries,
 };
 use crate::storage::cache::PageCache;
 use crate::storage::index::{AevtKey, AvetKey, EavtKey, FactRef, VaetKey, encode_value};
@@ -63,11 +64,12 @@ impl<B: StorageBackend + 'static> crate::storage::CommittedFactReader
         &self,
         fact_ref: crate::storage::index::FactRef,
     ) -> anyhow::Result<crate::graph::types::Fact> {
-        let backend = self
-            .backend
-            .lock()
-            .map_err(|_| anyhow::anyhow!("backend mutex poisoned"))?;
-        let page = self.page_cache.get_or_load(fact_ref.page_id, &*backend)?;
+        // Use MutexStorageBackend so the backend mutex is acquired only when
+        // get_or_load actually needs to read a cold page from disk. On cache
+        // hits get_or_load returns without ever calling read_page, so no lock
+        // is acquired and concurrent readers do not serialize.
+        let adapter = MutexStorageBackend(Arc::clone(&self.backend));
+        let page = self.page_cache.get_or_load(fact_ref.page_id, &adapter)?;
         crate::storage::packed_pages::read_slot(&page, fact_ref.slot_index)
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `CommittedFactLoaderImpl::resolve` acquired `Arc<Mutex<B>>` before calling `page_cache.get_or_load()`, so even warm-cache hits (which never call `read_page`) serialised all concurrent readers on one mutex
- **Trigger**: `daa80a9` (selective B+tree lookup, #208/#246) caused the query `[:e0 :val ?v]` to call `get_facts_by_attribute(\":val\")` returning all n FactRefs, each needing a `resolve()` call — 10k/100k mutex acquisitions vs the previous single `stream_all()` acquisition
- **Fix**: promote `MutexStorageBackend` to `pub(crate)` and use it in `resolve()`, matching the pattern already used by `OnDiskIndexReader::range_scan_*` — backend mutex is now held only for actual cold-page reads

## Benchmark results (local, fixed vs regressed CI)

| Benchmark | Regressed (CI 2026-05-16) | Fixed |
|---|---|---|
| 10k/2t | 22ms / 90 e/s | 22ms / 90 e/s |
| 10k/4t | 45ms / 89 e/s | **31ms / 127 e/s** (+43%) |
| 10k/8t | 70ms / 113 e/s | **57ms / 139 e/s** (+23%) |
| 100k/2t | 483ms / 4.1 e/s | 388ms / 5.1 e/s (+24%) |
| 100k/8t | 2.1s / 3.8 e/s | **1.48s / 5.4 e/s** (+42%, now correctly above 100k/4t) |

## Test plan

- [x] All 962 tests pass (pre-push hook)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] `concurrent_btree_scan` benchmarks show improved throughput scaling with thread count

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)