### PR TITLE
perf: pre-build MutexStorageBackend in CommittedFactLoaderImpl to eliminate per-resolve() Arc::clone (#280)

### DIFF
--- a/src/storage/persistent_facts.rs
+++ b/src/storage/persistent_facts.rs
@@ -73,7 +73,9 @@ impl<B: StorageBackend + 'static> crate::storage::CommittedFactReader
     ) -> anyhow::Result<crate::graph::types::Fact> {
         // backend_adapter is pre-built at construction time — no Arc::clone per call.
         // Backend mutex is only acquired inside adapter.read_page() on a cache miss.
-        let page = self.page_cache.get_or_load(fact_ref.page_id, &self.backend_adapter)?;
+        let page = self
+            .page_cache
+            .get_or_load(fact_ref.page_id, &self.backend_adapter)?;
         crate::storage::packed_pages::read_slot(&page, fact_ref.slot_index)
     }
 

--- a/src/storage/persistent_facts.rs
+++ b/src/storage/persistent_facts.rs
@@ -46,12 +46,19 @@ fn compute_index_checksum(facts: &[Fact]) -> u32 {
 /// Resolves FactRefs to Fact objects by reading packed pages from the backend
 /// through the page cache. Used after loading (or migrating) a v5/v6 file so that indexes can
 /// resolve committed facts without keeping the entire fact list in memory.
-// page_cache is read in the CommittedFactReader::resolve impl; Rust's dead-code
-// lint does not track trait-impl field reads when the impl is behind dyn dispatch.
+// Fields are read inside CommittedFactReader trait methods that are accessed via
+// dyn dispatch — Rust's dead-code lint does not track trait-impl field reads
+// when the impl is behind dyn dispatch.
 struct CommittedFactLoaderImpl<B: StorageBackend> {
+    #[allow(dead_code)]
     backend: Arc<Mutex<B>>,
     #[allow(dead_code)]
     page_cache: Arc<PageCache>,
+    /// Pre-built adapter reused on every `resolve()` call.
+    /// Avoids an `Arc::clone` per call: the adapter is constructed once and
+    /// holds the `Arc<Mutex<B>>` for the lifetime of this reader.
+    /// Backend mutex is still only acquired on cache misses (see `MutexStorageBackend`).
+    backend_adapter: MutexStorageBackend<B>,
     committed_fact_pages: Arc<AtomicU64>,
     #[allow(dead_code)]
     first_fact_page: u64, // always 1 in current layout
@@ -64,12 +71,9 @@ impl<B: StorageBackend + 'static> crate::storage::CommittedFactReader
         &self,
         fact_ref: crate::storage::index::FactRef,
     ) -> anyhow::Result<crate::graph::types::Fact> {
-        // Use MutexStorageBackend so the backend mutex is acquired only when
-        // get_or_load actually needs to read a cold page from disk. On cache
-        // hits get_or_load returns without ever calling read_page, so no lock
-        // is acquired and concurrent readers do not serialize.
-        let adapter = MutexStorageBackend(Arc::clone(&self.backend));
-        let page = self.page_cache.get_or_load(fact_ref.page_id, &adapter)?;
+        // backend_adapter is pre-built at construction time — no Arc::clone per call.
+        // Backend mutex is only acquired inside adapter.read_page() on a cache miss.
+        let page = self.page_cache.get_or_load(fact_ref.page_id, &self.backend_adapter)?;
         crate::storage::packed_pages::read_slot(&page, fact_ref.slot_index)
     }
 
@@ -295,6 +299,7 @@ impl<B: StorageBackend + 'static> PersistentFactStorage<B> {
         let loader: std::sync::Arc<dyn crate::storage::CommittedFactReader> =
             std::sync::Arc::new(CommittedFactLoaderImpl {
                 backend: self.backend.clone(),
+                backend_adapter: MutexStorageBackend(self.backend.clone()),
                 page_cache: self.page_cache.clone(),
                 committed_fact_pages: self.committed_fact_pages.clone(),
                 first_fact_page: 1,
@@ -781,6 +786,7 @@ impl<B: StorageBackend + 'static> PersistentFactStorage<B> {
         let loader: Arc<dyn crate::storage::CommittedFactReader> =
             Arc::new(CommittedFactLoaderImpl {
                 backend: self.backend.clone(),
+                backend_adapter: MutexStorageBackend(self.backend.clone()),
                 page_cache: self.page_cache.clone(),
                 committed_fact_pages: self.committed_fact_pages.clone(),
                 first_fact_page: 1,
@@ -990,6 +996,7 @@ impl<B: StorageBackend + 'static> PersistentFactStorage<B> {
         let loader: Arc<dyn crate::storage::CommittedFactReader> =
             Arc::new(CommittedFactLoaderImpl {
                 backend: self.backend.clone(),
+                backend_adapter: MutexStorageBackend(self.backend.clone()),
                 page_cache: self.page_cache.clone(),
                 committed_fact_pages: self.committed_fact_pages.clone(),
                 first_fact_page: 1,


### PR DESCRIPTION
## Summary

- **Root cause of #280**: #279 fixed concurrent mutex serialization in `resolve()` by using `MutexStorageBackend` instead of locking the backend before `get_or_load()`. However, it created `MutexStorageBackend(Arc::clone(&self.backend))` on **every** `resolve()` call — at 10k facts, that's 10k `Arc::clone` + 10k `Arc::drop` pairs per query iteration.
- **Regression confirmed** from CI logs: `query/point_attribute/10k` went from 24.117 ms (May 18, pre-#279) to 29.374 ms (May 20, post-#279) — **+22%**. Other large-dataset benchmarks regressed 8–17%. The 1k variants were unaffected, confirming the cost is per-call and proportional to fact count.
- **Fix**: Add `backend_adapter: MutexStorageBackend<B>` as a struct field on `CommittedFactLoaderImpl`, constructed once (one `Arc::clone` at init time). `resolve()` uses `&self.backend_adapter` directly — zero per-call overhead.
- **#279's concurrency fix is fully preserved**: `MutexStorageBackend` still only acquires the backend mutex inside `read_page()` on a cache miss. Concurrent readers are not serialized on cache hits.

## Test plan

- [x] 962 tests pass (`cargo test`)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] All 3 `CommittedFactLoaderImpl` construction sites updated

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)