### PR TITLE
perf(fix): restore per-pattern entity priority in selective_fact_fetch

### DIFF
--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -369,11 +369,12 @@ impl DatalogExecutor {
 
     /// Attempt a selective index-backed fact fetch for the given patterns.
     ///
-    /// Inspects `patterns` for bound entity literals (UUID or keyword → deterministic UUID)
-    /// and bound attribute keywords. If the total distinct lookup count is 0 (nothing bound)
-    /// or exceeds `threshold` (too many — full scan is cheaper), returns `None`.
-    /// Otherwise returns `Some(facts)` — the union of all selectively fetched facts,
-    /// deduplicated by `(entity, attribute, tx_count)`.
+    /// For each pattern, prefer a bound entity literal (UUID or keyword -> deterministic UUID)
+    /// over a bound attribute keyword for that same pattern. Entity lookups are usually more
+    /// selective, but multi-pattern joins still need attribute candidates for patterns that do not
+    /// bind an entity. If any pattern has neither a bound entity nor a bound attribute, or if the
+    /// distinct lookup count exceeds `threshold`, returns `None` to use a full scan. Otherwise
+    /// returns `Some(facts)`, deduplicated by `(entity, attribute, tx_count)`.
     fn selective_fact_fetch(&self, patterns: &[Pattern], threshold: usize) -> Option<Vec<Fact>> {
         use std::collections::HashSet;
 
@@ -381,21 +382,21 @@ impl DatalogExecutor {
         let mut attributes: HashSet<String> = HashSet::new();
 
         for pattern in patterns {
-            // Bound entity: UUID literal or keyword that resolves deterministically
-            match &pattern.entity {
-                EdnValue::Uuid(u) => {
-                    entity_ids.insert(*u);
-                }
-                EdnValue::Keyword(_) => {
-                    if let Ok(uid) = edn_to_entity_id(&pattern.entity) {
-                        entity_ids.insert(uid);
-                    }
-                }
-                _ => {}
+            let bound_entity = match &pattern.entity {
+                EdnValue::Uuid(u) => Some(*u),
+                EdnValue::Keyword(_) => edn_to_entity_id(&pattern.entity).ok(),
+                _ => None,
+            };
+
+            if let Some(uid) = bound_entity {
+                entity_ids.insert(uid);
+                continue;
             }
-            // Bound attribute: non-variable keyword
+
             if let AttributeSpec::Real(EdnValue::Keyword(attr)) = &pattern.attribute {
                 attributes.insert(attr.clone());
+            } else {
+                return None;
             }
         }
 
@@ -3798,6 +3799,33 @@ mod tests {
             "only open-ended fact visible at t=3000"
         );
         assert_eq!(facts_outside[0].attribute, ":person/name");
+    }
+
+    #[test]
+    fn test_selective_fetch_prefers_bound_entity_over_attribute_scan() {
+        let storage = FactStorage::new();
+        let executor = DatalogExecutor::new(storage);
+
+        let mut cmd = String::from(r#"(transact [[:e0 :val 0][:e0 :name "entity0"]"#);
+        for i in 1..=20 {
+            cmd.push_str(&format!("[:e{i} :val {i}]"));
+        }
+        cmd.push_str("])");
+        executor.execute(parse_datalog_command(&cmd).unwrap()).unwrap();
+
+        let query = match parse_datalog_command("(query [:find ?v :where [:e0 :val ?v]])")
+            .unwrap()
+        {
+            DatalogCommand::Query(query) => query,
+            _ => panic!("expected query"),
+        };
+
+        let facts = executor.filter_facts_for_query(&query).unwrap();
+        assert_eq!(
+            facts.len(),
+            2,
+            "bound entity + attribute query should fetch only the bound entity's facts"
+        );
     }
 }
 

--- a/src/query/datalog/executor.rs
+++ b/src/query/datalog/executor.rs
@@ -3811,10 +3811,11 @@ mod tests {
             cmd.push_str(&format!("[:e{i} :val {i}]"));
         }
         cmd.push_str("])");
-        executor.execute(parse_datalog_command(&cmd).unwrap()).unwrap();
+        executor
+            .execute(parse_datalog_command(&cmd).unwrap())
+            .unwrap();
 
-        let query = match parse_datalog_command("(query [:find ?v :where [:e0 :val ?v]])")
-            .unwrap()
+        let query = match parse_datalog_command("(query [:find ?v :where [:e0 :val ?v]])").unwrap()
         {
             DatalogCommand::Query(query) => query,
             _ => panic!("expected query"),


### PR DESCRIPTION
## Summary

- `bb43871` (#249) introduced `selective_fact_fetch` but incorrectly collected bound entities and bound attributes into two **separate** global sets, then issued lookups for **both** — even when a pattern already had a bound entity.
- For a point-lookup like `[:e0 :val ?v]` this caused a full attribute scan (`get_facts_by_attribute(":val")`) on top of the entity lookup, turning a µs operation into an ms scan at scale.
- Confirmed A/B regression in local Criterion runs: 2.3–4.9× slower across `concurrent_file/readers_plus_writer` variants; this matches the nightly Bencher signal starting May 16 (see #282).

## Fix

Per-pattern selectivity: for each pattern, if a bound entity is present, use the entity index and skip adding the attribute. If no bound entity but a bound attribute exists, use the attribute index. If a pattern has neither, fall back to a full scan (required for correctness — the fact universe cannot be restricted for that pattern).

## Regression Test

`test_selective_fetch_prefers_bound_entity_over_attribute_scan` — transacts 21 entities (e0..e20), queries `[:e0 :val ?v]`, asserts the candidate set is 2 facts (e0's facts only, not the 22 from entity ∪ attribute union). Test fails against the buggy code with `left: 22, right: 2`.

## Test Plan

- [x] `cargo test test_selective_fetch` — new regression test passes
- [x] `cargo test --test complex_queries_test` — 11/11 pass
- [x] `cargo test` — full suite passes (pre-push hook verified)

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)