### PR TITLE
ci: upgrade codecov-action v5 → v7 to fix GPG signature verification

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml

--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo llvm-cov --branch --lcov --output-path lcov.info
 
       - name: Upload branch coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info


### PR DESCRIPTION
## Summary

- Bumps `codecov/codecov-action` from v5 to v7 in both `coverage.yml` and `llvm-cov.yml`
- Fixes the nightly branch coverage CI failure seen in [run 27085716655](https://github.com/project-minigraf/minigraf/actions/runs/27085716655)

## Root cause

After Codecov was acquired by Harness, they migrated their Keybase account from `codecovsecurity` to `codecovsecops` and deleted the old account. This broke GPG signature verification in v5 and v6 of the action. v7 (released 2026-06-07) uses the new `codecovsecops` account and resolves the failure.

No endpoint changes, no token changes — version bump only.

## Test plan

- [ ] CI passes on this PR (coverage.yml uploads succeed)
- [ ] Nightly llvm-cov run passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)