### PR TITLE
fix(parser): allow '?' in keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Bug fixes
+
+- **Keywords may contain `?`**: `:person/alive?` now lexes as a single keyword. Previously `?` terminated the keyword, so `[:e :alive? true]` lexed as `:alive` followed by a stray `?` symbol and was rejected as a four-element fact — reporting `Optional 4th element of a fact must be a map`, which named the value rather than the keyword. `?` is a constituent character in EDN keywords and predicate-style names (`:artist/dead?`) are idiomatic. Query variables are unaffected: a `?` not preceded by `:` still begins a symbol. `tests/grammar/grammar.pest` updated to match.
+
 ## v1.2.3 — 2026-08-10
 
 No changes to the core crate. Released so the language bindings have a version
@@ -29,7 +35,6 @@ Drop-in replacement for v1.2.1. No file-format changes, no public API changes.
 - **Two handles on one file in the same process** (#304): `FileLock::acquire` treated a lock file whose holder PID equalled our own as stale, deleted it, and opened anyway — on the theory that it could only be a leaked handle. The far more likely cause is a handle that is open and in use right now elsewhere in the process, so the "self-heal" silently produced two live `FileBackend`s on one file. Each caches its own `header.page_count`, allocates new pages from that count, and bounds-checks `read_page` against it, so the two page tables diverge. That — not an allocation off-by-one — is the source of the intermittent `Page N out of bounds (total pages: M)`. It also corrupted the lock itself: whichever handle dropped first ran `FileLock::drop` and removed the lock file that by then belonged to the survivor, leaving a live handle unlocked and admitting other processes too. A lock held by our own PID is now refused with an error naming the same-process case; a lock held by a *different*, dead process is still reclaimed as before. **Behaviour change:** callers that relied on reopening a path they already hold open now get an error instead of silent corruption, and should reuse the existing handle (`Minigraf` is cheap to clone and all clones share one database).
 
 - **String comparison in predicates**: `[(< ?a ?b)]`, `>`, `<=` and `>=` now order two strings lexicographically instead of failing. Previously every ordering predicate routed through `to_float_pair`, which errors on non-numeric operands, so a string comparison silently matched no rows — and because both directions returned nothing, a range filter dropped the entire relation rather than partitioning it. This most often bit ISO-8601 timestamps stored as strings. The predicate path now agrees with `value_lt` / `value_cmp`, which `min`, `max` and `:order-by` already use. Mixed-type comparison (string vs number) remains an error, and NaN comparisons remain false.
-- **Keywords may contain `?`**: `:person/alive?` now lexes as a single keyword. Previously `?` terminated the keyword, so `[:e :alive? true]` lexed as `:alive` followed by a stray `?` symbol and was rejected as a four-element fact — reporting `Optional 4th element of a fact must be a map`, which named the value rather than the keyword. `?` is a constituent character in EDN keywords and predicate-style names (`:artist/dead?`) are idiomatic. Query variables are unaffected: a `?` not preceded by `:` still begins a symbol. `tests/grammar/grammar.pest` updated to match.
 
 ## v1.2.1 — 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 - **String comparison in predicates**: `[(< ?a ?b)]`, `>`, `<=` and `>=` now order two strings lexicographically instead of failing. Previously every ordering predicate routed through `to_float_pair`, which errors on non-numeric operands, so a string comparison silently matched no rows — and because both directions returned nothing, a range filter dropped the entire relation rather than partitioning it. This most often bit ISO-8601 timestamps stored as strings. The predicate path now agrees with `value_lt` / `value_cmp`, which `min`, `max` and `:order-by` already use. Mixed-type comparison (string vs number) remains an error, and NaN comparisons remain false.
+- **Keywords may contain `?`**: `:person/alive?` now lexes as a single keyword. Previously `?` terminated the keyword, so `[:e :alive? true]` lexed as `:alive` followed by a stray `?` symbol and was rejected as a four-element fact — reporting `Optional 4th element of a fact must be a map`, which named the value rather than the keyword. `?` is a constituent character in EDN keywords and predicate-style names (`:artist/dead?`) are idiomatic. Query variables are unaffected: a `?` not preceded by `:` still begins a symbol. `tests/grammar/grammar.pest` updated to match.
 
 ## v1.2.1 — 2026-06-28
 

--- a/src/query/datalog/parser.rs
+++ b/src/query/datalog/parser.rs
@@ -103,7 +103,10 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 chars.next();
                 let mut keyword = String::from(":");
                 while let Some(&ch) = chars.peek() {
-                    if ch.is_alphanumeric() || ch == '/' || ch == '-' || ch == '_' {
+                    // '?' is a constituent character, matching symbols (see below) and
+                    // EDN itself — predicate-style names like :person/alive? are idiomatic.
+                    // A keyword can never be a query variable, so there is no ambiguity.
+                    if ch.is_alphanumeric() || ch == '/' || ch == '-' || ch == '_' || ch == '?' {
                         if keyword.len() >= MAX_KEYWORD_LENGTH {
                             return Err(format!(
                                 "Keyword exceeds maximum length of {} bytes",
@@ -1930,6 +1933,35 @@ mod tests {
         let result = tokenize(&long_keyword);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("exceeds maximum length"));
+    }
+
+    #[test]
+    fn test_tokenize_keyword_with_question_mark() {
+        // Regression: '?' ended the keyword, so ":attended?" lexed as
+        // Keyword(":attended") + Symbol("?"), turning a three-element fact into
+        // four and reporting the value as a bogus fourth element.
+        let tokens = tokenize("[:a :attended? true]").unwrap();
+        assert_eq!(tokens.len(), 5, "expected 5 tokens");
+        assert_eq!(tokens[2], Token::Keyword(":attended?".to_string()));
+    }
+
+    #[test]
+    fn test_tokenize_keyword_question_mark_positions() {
+        // Leading, infix, trailing and namespaced forms all stay in one token.
+        let tokens = tokenize(":?x :att?end :alive? :person/alive?").unwrap();
+        assert_eq!(tokens[0], Token::Keyword(":?x".to_string()));
+        assert_eq!(tokens[1], Token::Keyword(":att?end".to_string()));
+        assert_eq!(tokens[2], Token::Keyword(":alive?".to_string()));
+        assert_eq!(tokens[3], Token::Keyword(":person/alive?".to_string()));
+    }
+
+    #[test]
+    fn test_tokenize_variable_still_lexes_as_symbol() {
+        // A '?' that does not follow ':' still starts a query variable.
+        let tokens = tokenize("[?e :alive? ?v]").unwrap();
+        assert_eq!(tokens[1], Token::Symbol("?e".to_string()));
+        assert_eq!(tokens[2], Token::Keyword(":alive?".to_string()));
+        assert_eq!(tokens[3], Token::Symbol("?v".to_string()));
     }
 
     #[test]

--- a/tests/datomic_compat_test.rs
+++ b/tests/datomic_compat_test.rs
@@ -268,6 +268,70 @@ fn datomic_predicate_expression_filter() {
     assert_eq!(adults, 3, "entities with age >= 18: a, b, d");
 }
 
+// ── Datomic concept: predicate-style attribute names ─────────────────────────
+
+/// Datomic concept: attribute keywords may end in '?', following the Clojure
+/// convention for predicates (`:artist/dead?`). Regression test — '?' formerly
+/// terminated the keyword, so `:person/alive?` lexed as `:person/alive` plus a
+/// stray symbol, which made a three-element fact look like a four-element one.
+/// Datomic doc reference: "Schema" — attribute naming.
+#[test]
+fn datomic_attribute_keyword_may_end_in_question_mark() {
+    let db = Minigraf::in_memory().unwrap();
+    db.execute(
+        r#"(transact [
+        [:user42 :person/alive? true]
+        [:user43 :person/alive? false]
+    ])"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        count_results(
+            db.execute(r#"(query [:find ?e ?v :where [?e :person/alive? ?v]])"#)
+                .unwrap()
+        ),
+        2,
+        "both predicate-named facts must be queryable"
+    );
+
+    // The value binds correctly, so the fact was stored as (e, a, v) and not
+    // misread as a fact with a spurious fourth element.
+    let alive = db
+        .execute(r#"(query [:find ?e :where [?e :person/alive? true]])"#)
+        .unwrap();
+    assert_eq!(count_results(alive), 1, "exactly one entity is alive");
+}
+
+/// A '?' in value position stays a keyword too, and query variables are
+/// unaffected — only keywords changed.
+#[test]
+fn datomic_keyword_value_may_end_in_question_mark() {
+    let db = Minigraf::in_memory().unwrap();
+    db.execute(r#"(transact [[:job1 :job/state :ready?]])"#)
+        .unwrap();
+
+    let by_value = db
+        .execute(r#"(query [:find ?e :where [?e :job/state :ready?]])"#)
+        .unwrap();
+    assert_eq!(count_results(by_value), 1, "keyword value must match");
+
+    match db
+        .execute(r#"(query [:find ?s :where [?e :job/state ?s]])"#)
+        .unwrap()
+    {
+        QueryResult::QueryResults { results, .. } => {
+            assert_eq!(results.len(), 1, "expected one binding");
+            assert_eq!(
+                results[0][0],
+                Value::Keyword(":ready?".to_string()),
+                "value must round-trip with its '?'"
+            );
+        }
+        _ => panic!("expected query results"),
+    }
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // SKIPPED CASES
 // ═════════════════════════════════════════════════════════════════════════════

--- a/tests/grammar/grammar.pest
+++ b/tests/grammar/grammar.pest
@@ -32,8 +32,8 @@ uuid_lit = { "#uuid" ~ string_lit }
 // Prepared-query bind slot: $name
 bind_slot = @{ "$" ~ (ASCII_ALPHANUMERIC | "_" | "-")+ }
 
-// Keyword: starts with ":", followed by alphanumeric, "/", "-", "_"
-keyword = @{ ":" ~ (ASCII_ALPHANUMERIC | "/" | "-" | "_")+ }
+// Keyword: starts with ":", followed by alphanumeric, "/", "-", "_", "?"
+keyword = @{ ":" ~ (ASCII_ALPHANUMERIC | "/" | "-" | "_" | "?")+ }
 
 // Logic variable: starts with "?"
 variable = @{ "?" ~ word_cont* }

--- a/tests/grammar/grammar.pest
+++ b/tests/grammar/grammar.pest
@@ -32,8 +32,8 @@ uuid_lit = { "#uuid" ~ string_lit }
 // Prepared-query bind slot: $name
 bind_slot = @{ "$" ~ (ASCII_ALPHANUMERIC | "_" | "-")+ }
 
-// Keyword: starts with ":", followed by alphanumeric, "/", "-", "_", "?"
-keyword = @{ ":" ~ (ASCII_ALPHANUMERIC | "/" | "-" | "_" | "?")+ }
+// Keyword: starts with ":", followed by word constituents (incl. "?")
+keyword = @{ ":" ~ word_cont+ }
 
 // Logic variable: starts with "?"
 variable = @{ "?" ~ word_cont* }

--- a/tests/grammar/valid/edn_keyword_question_mark.edn
+++ b/tests/grammar/valid/edn_keyword_question_mark.edn
@@ -1,0 +1,5 @@
+(transact [[:e1 :person/alive? true]
+           [:e2 :alive? false]
+           [:e3 :att?end "infix"]
+           [:e4 :?leading "leading"]
+           [:e5 :state :ready?]])

--- a/tests/xtdb_compat_test.rs
+++ b/tests/xtdb_compat_test.rs
@@ -285,6 +285,150 @@ fn xtdb_recursive_ancestor_rule() {
     );
 }
 
+// ── Predicate-style keyword names ─────────────────────────────────────────────
+
+/// XTDB concept: attributes are EDN keywords, and names ending in '?' are the
+/// idiomatic Clojure spelling for a predicate (`:artist/dead?`).
+///
+/// Regression test — '?' formerly terminated the keyword token, so
+/// `:artist/dead?` lexed as `:artist/dead` followed by a stray symbol, and a
+/// three-element fact was read as a four-element one.
+/// Source: XTDB "Data Model" — documents are EDN; attributes are keywords.
+#[test]
+fn xtdb_attribute_keyword_may_end_in_question_mark() {
+    let db = Minigraf::in_memory().unwrap();
+    db.execute(
+        r#"(transact [
+        [:pablo    :artist/dead? true]
+        [:salvador :artist/dead? true]
+        [:banksy   :artist/dead? false]
+    ])"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        count_results(
+            db.execute(r#"(query [:find ?e ?v :where [?e :artist/dead? ?v]])"#)
+                .unwrap()
+        ),
+        3,
+        "every predicate-named fact must be queryable"
+    );
+
+    // Binding by value proves the fact was stored as (e, a, v) rather than
+    // being misread as a fact with a spurious fourth element.
+    assert_eq!(
+        count_results(
+            db.execute(r#"(query [:find ?e :where [?e :artist/dead? false]])"#)
+                .unwrap()
+        ),
+        1,
+        "exactly one artist is living"
+    );
+}
+
+/// XTDB concept: a keyword is a legal attribute *value*, so entities can be
+/// joined on one — and it keeps its '?' through storage and back.
+/// Source: XTDB "Data Model" — keyword values.
+#[test]
+fn xtdb_keyword_value_may_end_in_question_mark() {
+    let db = Minigraf::in_memory().unwrap();
+    db.execute(
+        r#"(transact [
+        [:job1 :job/state :ready?]
+        [:job2 :job/state :blocked?]
+        [:job3 :job/state :ready?]
+    ])"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        count_results(
+            db.execute(r#"(query [:find ?e :where [?e :job/state :ready?]])"#)
+                .unwrap()
+        ),
+        2,
+        "two jobs are ready"
+    );
+
+    match db
+        .execute(r#"(query [:find ?s :where [:job2 :job/state ?s]])"#)
+        .unwrap()
+    {
+        QueryResult::QueryResults { results, .. } => {
+            assert_eq!(results.len(), 1, "expected one binding");
+            assert_eq!(
+                results[0][0],
+                Value::Keyword(":blocked?".to_string()),
+                "value must round-trip with its '?'"
+            );
+        }
+        _ => panic!("expected query results"),
+    }
+}
+
+/// XTDB concept: retraction targets one fact, and a predicate-named attribute
+/// is no different. Exercises the write path, where the original defect turned
+/// a three-element fact into a rejected four-element one.
+/// Source: XTDB "Transactions" — retract.
+#[test]
+fn xtdb_retract_predicate_named_attribute() {
+    let db = Minigraf::in_memory().unwrap();
+    db.execute(r#"(transact [[:alice :person/admin? true] [:alice :name "Alice"]])"#)
+        .unwrap();
+
+    db.execute(r#"(retract [[:alice :person/admin? true]])"#)
+        .unwrap();
+
+    assert_eq!(
+        count_results(
+            db.execute(r#"(query [:find ?v :where [?e :person/admin? ?v]])"#)
+                .unwrap()
+        ),
+        0,
+        "the predicate-named fact should be retracted"
+    );
+    assert_eq!(
+        query_strings(&db, r#"(query [:find ?n :where [?e :name ?n]])"#),
+        vec!["Alice".to_string()],
+        "the other fact should survive"
+    );
+}
+
+/// XTDB concept: bitemporality applies to predicate-named attributes like any
+/// other. Valid-time filtering is a separate path from a plain match, so a
+/// keyword that survives parsing must survive it too.
+/// Source: XTDB "Bitemporality" — valid-time queries.
+#[test]
+fn xtdb_valid_time_query_over_predicate_named_attribute() {
+    let db = Minigraf::in_memory().unwrap();
+    db.execute(
+        r#"(transact {:valid-from "2023-01-01" :valid-to "2023-12-31"} [[:contract :contract/active? true]])"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        count_results(
+            db.execute(
+                r#"(query [:find ?v :valid-at "2023-06-01" :where [?e :contract/active? ?v]])"#
+            )
+            .unwrap()
+        ),
+        1,
+        "visible within the valid-time range"
+    );
+    assert_eq!(
+        count_results(
+            db.execute(
+                r#"(query [:find ?v :valid-at "2024-01-01" :where [?e :contract/active? ?v]])"#
+            )
+            .unwrap()
+        ),
+        0,
+        "not visible after the valid-to boundary"
+    );
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // SKIPPED CASES
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

`?` terminated the keyword token, so `:person/alive?` lexed as `Keyword(":person/alive")` followed by `Symbol("?")`. A three-element fact then looked like a four-element one, and attempts to transact would give a misleading error:

```
  (transact [[:e :alive? true]])
  -> Optional 4th element of a fact must be a map, got Boolean(true)
```

`?` is a constituent character in EDN keywords, and predicate-style names are idiomatic in Datalog. Keywords are introduced by `:` and can never be query variables, so admitting `?` is unambiguous; a `?` not preceded by `:` still starts a symbol.

Position is irrelevant to the bug — leading, infix and trailing all failed — so the fix is to the character class, not a trailing-sigil rule.

`tests/grammar/grammar.pest` updated to keep pest and the parser in agreement, as grammar_conformance requires.


## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (requires migration or version bump)
- [ ] Documentation / tests only

## Checklist

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` is clean
- [x] `cargo fmt --check` passes
- [x] New code has tests (unit and/or integration)
- [x] Error paths are tested, not just happy paths
- [x] No `unwrap()` / `expect()` in library code paths
- [x] `CHANGELOG.md` updated under `Unreleased`
- [x] I have read [PHILOSOPHY.md](../PHILOSOPHY.md) and this change aligns with it

## Notes for reviewer

I consider this a non-breaking change, because it doesn't reinterpret or reject any existing valid inputs. I hope you agree!
