### PR TITLE
fix(temporal): avoid byte-index panic on non-UTF-8-boundary input

### DIFF
--- a/fuzz/corpus/datalog_eval/seed_temporal_multibyte_char_boundary.bin
+++ b/fuzz/corpus/datalog_eval/seed_temporal_multibyte_char_boundary.bin
@@ -1,0 +1,1 @@
+(query [:::as-of"f[r[Y[[r[؅f"n_1])

--- a/src/temporal.rs
+++ b/src/temporal.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 /// - Any string with a timezone offset (e.g., `+05:30`) — use UTC (Z) only.
 pub fn parse_timestamp(s: &str) -> Result<i64> {
     // Reject timezone offsets explicitly
-    if s.contains('+') || (s.len() > 10 && s[10..].contains('-')) {
+    if s.contains('+') || s.get(10..).is_some_and(|rest| rest.contains('-')) {
         return Err(anyhow!(
             "timezone offsets are not supported; use UTC (Z) timestamps only. \
              chrono's local timezone handling (GHSA-wcg3-cvx6-7396) is avoided by design."
@@ -89,6 +89,14 @@ mod tests {
     #[test]
     fn test_reject_invalid_string() {
         assert!(parse_timestamp("not-a-date").is_err());
+    }
+
+    #[test]
+    fn test_multibyte_char_near_byte_offset_10_does_not_panic() {
+        // Byte offset 10 falls inside the 2-byte UTF-8 encoding of '\u{605}',
+        // which starts at byte 9. Slicing s[10..] would panic on a non-char-boundary.
+        let s = "123456789\u{605}abc";
+        assert!(parse_timestamp(s).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `parse_timestamp` sliced `s[10..]` to check for a timezone-offset dash, which panics when byte offset 10 falls inside a multi-byte UTF-8 character
- Discovered by the nightly `datalog_eval` fuzzer on `:as-of` query strings containing non-ASCII characters (crash artifact `crash-012232f88967026da67f1548a7d90910f6134d8a`, same root cause as #319)
- Switched to `s.get(10..)`, which returns `None` on an out-of-range or non-boundary index instead of panicking

## Test plan
- [x] Added `test_multibyte_char_near_byte_offset_10_does_not_panic` — reproduces the exact panic before the fix, passes after
- [x] Added fuzz corpus seed `fuzz/corpus/datalog_eval/seed_temporal_multibyte_char_boundary.bin` matching the crashing fuzzer input
- [x] `cargo test` — all 667+ tests pass across all suites
- [x] pre-push hooks (fmt, clippy, full test suite) pass

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMWSutMLJJ7Y5b8hs9ZaCU