### PR TITLE
docs: fix dangling intra-doc link to test-only FileBackend::open

### DIFF
--- a/src/storage/backend/file.rs
+++ b/src/storage/backend/file.rs
@@ -165,7 +165,7 @@ impl FileBackend {
         Self::open_with(path, false)
     }
 
-    /// As [`FileBackend::open`], but `allow_unlocked` permits opening on a
+    /// As `FileBackend::open` (test-only), but `allow_unlocked` permits opening on a
     /// filesystem that cannot lock at all.
     ///
     /// `allow_unlocked` does NOT override a lock held by someone else. It


### PR DESCRIPTION
## Summary
- `open_with`'s doc comment links to `[FileBackend::open]`, which is `#[cfg(test)]`-gated and unresolvable in a non-test doc build. Replaced with a plain code span.

Fixes #328

## Test plan
- [x] `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --document-private-items --no-deps` no longer reports the `FileBackend::open` link (remaining unresolved links are pre-existing/unrelated, confirmed present on `main`)
- [x] `cargo doc --all-features --no-deps` (CI's docs-check command) passes clean
- [x] `cargo test` — all tests pass

https://claude.ai/code/session_01YMWSutMLJJ7Y5b8hs9ZaCU