### PR TITLE
fix: build pid_ns_helper for cargo-llvm-cov and raise an issue on nightly branch-coverage failure

### DIFF
--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   llvm-cov:
@@ -24,7 +25,18 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Build the pid_ns_helper example used by lock tests
+        # cargo-llvm-cov's instrumented build places test binaries under a
+        # build-script-shaped path (target/llvm-cov-target/debug/build/...),
+        # so docker_lock_test.rs's `examples/`-relative-to-test-binary lookup
+        # never finds the helper. Same workaround as coverage.yml's
+        # tarpaulin job: build it into a target dir cargo-llvm-cov never
+        # touches and point the tests at it directly.
+        run: cargo build --examples --target-dir /tmp/minigraf-lock-test-examples
+
       - name: Generate branch coverage report
+        env:
+          MINIGRAF_PID_NS_HELPER: /tmp/minigraf-lock-test-examples/debug/examples/pid_ns_helper
         run: cargo llvm-cov --branch --lcov --output-path lcov.info
 
       - name: Upload branch coverage to Codecov
@@ -36,6 +48,8 @@ jobs:
           fail_ci_if_error: true
 
       - name: Generate HTML report
+        env:
+          MINIGRAF_PID_NS_HELPER: /tmp/minigraf-lock-test-examples/debug/examples/pid_ns_helper
         run: cargo llvm-cov --branch --html
 
       - name: Upload HTML report as artifact
@@ -44,3 +58,35 @@ jobs:
           name: llvm-cov-html
           path: target/llvm-cov/html/
           retention-days: 30
+
+      - name: Record branch-coverage failure
+        if: ${{ failure() }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: "Nightly branch-coverage failure"
+        run: |
+          report_file="branch-coverage-failure.md"
+          {
+            echo "The nightly branch coverage job failed."
+            echo
+            echo "- Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- Logs: see the \"cargo-llvm-cov branch coverage\" job in the run above;"
+            echo "  see the \"llvm-cov\" job in .github/workflows/llvm-cov.yml"
+          } > "$report_file"
+
+          existing_issue="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$ISSUE_TITLE in:title" \
+            --json number,title \
+            --limit 100 \
+            --jq '.[] | select(.title == "Nightly branch-coverage failure") | .number' \
+            | head -n 1)"
+
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --repo "$GITHUB_REPOSITORY" --body-file "$report_file"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" --body-file "$report_file"
+          fi


### PR DESCRIPTION
## Summary
- `docker_lock_test.rs` locates `pid_ns_helper` relative to the test binary's own path. `cargo-llvm-cov`'s instrumented build places test binaries under a build-script-shaped directory (`target/llvm-cov-target/debug/build/minigraf/<hash>/out/...`), so that lookup always misses and the test panics instead of skipping — breaking the nightly "Branch Coverage (nightly)" workflow (run [32688207889](https://github.com/project-minigraf/minigraf/actions/runs/32688207889)).
- Fixes it by applying the same `MINIGRAF_PID_NS_HELPER` workaround `coverage.yml` already uses for tarpaulin: build the example into a separate target dir cargo-llvm-cov never touches and point the tests at it.
- Adds a failure step that files/comments on a tracking issue when the nightly run fails, mirroring the pattern already used in `nfs-lock.yml`.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` all pass locally (pre-push hook)
- [ ] Nightly `Branch Coverage (nightly)` workflow run is green
- [ ] Trigger via `workflow_dispatch` to confirm the fix before the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)