### PR TITLE
fix: honor MINIGRAF_PID_NS_HELPER in pid_namespace_test.rs

### DIFF
--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Build the pid_ns_helper example used by lock tests
         # cargo-llvm-cov's instrumented build places test binaries under a
         # build-script-shaped path (target/llvm-cov-target/debug/build/...),
-        # so docker_lock_test.rs's `examples/`-relative-to-test-binary lookup
+        # so the lock tests' `examples/`-relative-to-test-binary lookup
+        # (docker_lock_test.rs, nfs_lock_test.rs, pid_namespace_test.rs)
         # never finds the helper. Same workaround as coverage.yml's
         # tarpaulin job: build it into a target dir cargo-llvm-cov never
         # touches and point the tests at it directly.

--- a/tests/pid_namespace_test.rs
+++ b/tests/pid_namespace_test.rs
@@ -90,7 +90,16 @@ fn spawn_in_namespace(
 }
 
 /// Path to the compiled helper binary (see `examples/pid_ns_helper.rs`).
+///
+/// `MINIGRAF_PID_NS_HELPER`, if set, is used as-is -- needed under
+/// `cargo-llvm-cov`, whose instrumented build places test binaries under a
+/// build-script-shaped path instead of `target/debug/deps/`, breaking the
+/// relative lookup below. See `tests/docker_lock_test.rs::helper_binary` for
+/// the same pattern.
 fn helper_binary() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("MINIGRAF_PID_NS_HELPER") {
+        return std::path::PathBuf::from(path);
+    }
     // target/debug/examples/pid_ns_helper, resolved relative to the test binary
     // at target/debug/deps/pid_namespace_test-<hash>.
     let mut dir = std::env::current_exe().expect("test binary path");


### PR DESCRIPTION
## Summary
- Follow-up to #345. That PR fixed `docker_lock_test.rs`'s helper-binary lookup under `cargo-llvm-cov`'s instrumented build, but the nightly run ([32693053052](https://github.com/project-minigraf/minigraf/actions/runs/32693053052)) still failed on the same root cause in `pid_namespace_test.rs`: its `helper_binary()` never gained the `MINIGRAF_PID_NS_HELPER` override that `docker_lock_test.rs`/`nfs_lock_test.rs` already had, so it panicked once `unshare` succeeded on the nightly runner.
- Adds the same env-var override to `pid_namespace_test.rs::helper_binary()`.
- Updates the `.github/workflows/llvm-cov.yml` comment to mention all three lock-test files affected by this lookup quirk (the env var itself was already wired to both `cargo llvm-cov` steps in #345).

Fixes #346

## Test plan
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` all pass locally (pre-push hook)
- [x] `MINIGRAF_PID_NS_HELPER=<path> cargo test --test pid_namespace_test` passes locally with a helper built into an out-of-tree target dir, confirming the override path works
- [ ] Nightly `Branch Coverage (nightly)` workflow run is green
- [ ] Trigger via `workflow_dispatch` to confirm before the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)