### PR TITLE
fix: warm up NFSv4 lock state before the timed race in nfs_lock_test

### DIFF
--- a/tests/nfs_lock_test.rs
+++ b/tests/nfs_lock_test.rs
@@ -113,6 +113,30 @@ fn nfsv3_nolock_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// #343: the first lock ever taken on a freshly mounted loopback NFSv4
+/// export can stall for tens of seconds (observed ~57s locally, in line with
+/// the mount's default 60s RPC timeout) before the kernel even attempts the
+/// lock -- almost certainly one-time NFSv4 lock-state/callback-channel setup
+/// between this host acting as both client and server. That stall lands on
+/// whichever process asks first, so it hits the holder spawned below and the
+/// second opener at nearly the same moment, erasing the head start the
+/// holder would otherwise have (it creates the database and calls
+/// `try_lock` on the very next line) and turning "holder always wins" into a
+/// coin flip. Paying that cost here, before the timed race, keeps it out of
+/// the assertion below. Confirmed locally: back-to-back lock cycles on one
+/// mount pay the stall only once; every cycle after is exclusive and
+/// effectively instant.
+fn warm_up_locking(mount: &Path, helper: &Path) {
+    let db = mount.join("warmup.graph");
+    let out = run_helper(helper, &db, "open");
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("OPEN_OK"),
+        "[warm-up] open failed on {}; cannot proceed to the timed race.\nstderr: {}",
+        mount.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// While a holder is alive on the mount, a second open must never report
 /// success. This is the core #324 assertion: genuinely exclusive, or
 /// refused — a silent no-op (both processes believing they hold the lock) is
@@ -120,6 +144,7 @@ fn nfsv3_nolock_dir() -> Option<PathBuf> {
 fn assert_lock_excludes_second_holder(mount: &Path, label: &str) {
     let helper = helper_binary();
     require_helper_built(&helper);
+    warm_up_locking(mount, &helper);
 
     let db = mount.join(format!("{label}.graph"));
     let release = mount.join(format!("{label}-release"));


### PR DESCRIPTION
## Summary
- Fixes #343 (nightly NFS lock-suite failure): `test_lock_is_exclusive_over_nfsv4` flaked because the *first* lock ever taken on a freshly mounted loopback NFSv4 export can stall for tens of seconds (~57s locally, in line with the mount's default 60s RPC timeout) before the kernel even attempts the lock — almost certainly one-time NFSv4 lock-state/callback-channel setup between the runner acting as both client and server.
- That stall lands on whichever process asks first, hitting the spawned holder and the second opener at nearly the same moment. It erases the head start the holder should have (it creates the database and calls `try_lock` on the very next line), turning "holder always wins" into a coin flip.
- Fix: `assert_lock_excludes_second_holder` now does a throwaway `open` against the mount before spawning the holder, paying the one-time warm-up cost during setup instead of inside the timed race.

## Investigation
Reproduced locally against a real loopback NFSv4 mount (`systemd-nspawn`/container isolation wasn't viable — `rpcbind`/`rpc.mountd` detach from any namespace and nfsd's kernel thread pool isn't namespace-scoped — so this ran directly on the host with a cleanup trap restoring all state). Confirmed with timing instrumentation that:
- `FileBackend`'s kernel locking (`src/storage/backend/file.rs`) is correct throughout — a holder's exclusive lock is always genuinely respected. No code changes needed there.
- Raw `flock(1)`, including a retried-on-the-same-fd pattern (matching `open_with`'s `WouldBlock` retry loop) against an unambiguous, un-releasable holder (fixed `sleep 10`, no early release possible), stayed correctly exclusive across dozens of trials.
- The flake is a test-timing artifact of the one-time NFS warm-up cost landing inside the race window, not a locking bug.

## Test plan
- [x] `cargo test --test nfs_lock_test` against a real loopback NFSv4 mount: all 6 tests pass (previously flaked on `test_lock_is_exclusive_over_nfsv4`)
- [x] Full `cargo test` suite passes (690 lib tests + all integration suites)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features -- -D warnings` (CI's exact invocation) clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Nsh3ZnmoK6PTaUbp4HcqHY