### PR TITLE
security: scope cascade/docs-check workflow permissions

### DIFF
--- a/.github/workflows/cascade.yml
+++ b/.github/workflows/cascade.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   dispatch-bindings:
     name: Dispatch to binding repos

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,6 +6,9 @@ on:
       - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docs-check:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `.github/workflows/cascade.yml` and `.github/workflows/docs-check.yml`
- Fixes CodeQL alerts [#85](https://github.com/project-minigraf/minigraf/security/code-scanning/85) and [#86](https://github.com/project-minigraf/minigraf/security/code-scanning/86) (`actions/missing-workflow-permissions`)
- Neither workflow needs write access via the default `GITHUB_TOKEN`: `cascade.yml` doesn't check out the repo and authenticates its cross-repo dispatch calls with the separate `MINIGRAF_RELEASE_TOKEN` secret; `docs-check.yml` only builds docs read-only

## Test plan
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` (706 passed) via pre-push hook
- [x] YAML unchanged apart from added `permissions` block; workflow triggers/logic untouched

https://claude.ai/code/session_01P7e4uTBWtM8fMZiPZc4bCw