### PR TITLE
fix: correct :as-of query syntax in long-haul smoke test

### DIFF
--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -123,11 +123,8 @@ fn smoke_large_graph_10_cycles() {
 
         // Invariant 5: temporal query (:as-of 1) returns data from tx 1.
         let n_temporal = count_results(
-            db.execute("(query [:find ?e :where [?e :version 1]] :as-of 1)")
-                .unwrap_or(QueryResult::QueryResults {
-                    vars: vec![],
-                    results: vec![],
-                }),
+            db.execute("(query [:find ?e :as-of 1 :where [?e :version 1]])")
+                .unwrap(),
         );
         // Should return some results — exact count depends on tx ordering.
         // Just verify it doesn't error and returns > 0 for tx 1.


### PR DESCRIPTION
## Summary
- Nightly smoke suite (run [32813615890](https://github.com/project-minigraf/minigraf/actions/runs/32813615890)) failed on `main` with `cycle 0: temporal query :as-of 1 returned no results`.
- Root cause: `tests/smoke_test.rs` invariant 5 placed `:as-of 1` as a trailing argument outside the query vector (`(query [...] :as-of 1)`) instead of inside it after `:find` (`(query [:find ?e :as-of 1 :where ...])`). This is a parse error, which the test silently swallowed via `.unwrap_or(empty results)`, so the `n_temporal > 0` assertion always failed.
- This is a test bug, not a database bug — confirmed the correct syntax returns the expected results, both in a standalone repro and by fixing and rerunning the full 10-cycle smoke test.

## Test plan
- [x] `cargo test --test smoke_test -- --ignored --nocapture` — 10/10 cycles pass
- [x] `cargo test` (full suite) — all passing
- [x] pre-push hook (fmt + clippy + test) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eyz8Dwa9PihVTbG7MfTLL