### PR TITLE
chore: raise binary-size CI budget from 1MB to ~1.2MB for #277

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check release binary size
     runs-on: ubuntu-latest
     env:
-      SIZE_LIMIT_BYTES: 1048576  # 1 MiB — project goal is <1MB
+      SIZE_LIMIT_BYTES: 1228800  # 1200 KiB — raised from 1 MiB for #277's structured error codes; see PHILOSOPHY.md §4
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   canonical `{}`-placeholder template form so the registry↔doc sync test can
   compare them byte-for-byte; the concrete example now lives in each entry's
   prose instead.
+- **The core binary size budget is raised from 1MB to ~1.2MB** (`binary-size.yml`'s
+  `SIZE_LIMIT_BYTES`, and PHILOSOPHY.md §4's stated target), toward #277.
+  The project was already at the 1MB wire before #277 started (measured
+  ~1034 KiB pre-rollout on a controlled local build); #360 (WAL, 6 codes) and
+  #361 (QRY, 9 codes) together added only ~9 KiB, and even that was enough to
+  fail CI. All existing size levers — `opt-level = "z"`, `lto = true`,
+  `codegen-units = 1`, `strip = "symbols"`, and the non-generic
+  `bail_coded!`/`err_coded!`/`format_template` design (no per-call-site
+  monomorphization, unlike the generic `build_btree` fixed for the same
+  reason in v0.x) — were already in place; `cargo bloat` shows no single
+  dominant symbol to cut, just diffuse growth across ~2000 small functions.
+  Extrapolating to the full 130-code rollout (PRS: 79, STG: 27, WAL: 6,
+  QRY: 9, API+INT: 9) puts the total growth at roughly 60-70 KiB over the
+  pre-#277 baseline, which no further micro-optimization of already-maxed
+  settings can absorb. ~1.2MB keeps meaningful headroom above that projection
+  without abandoning the philosophy's small-binary principle.
 
 ### Bug fixes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Minigraf follows the "SQLite for bi-temporal graph databases" philosophy:
 - **Zero-configuration** - No setup, no config files, just works
 - **Embedded-first** - Library not server, in-process execution
 - **Single-file database** - One portable `.graph` file
-- **Self-contained** - Minimal dependencies, small binary (<1MB goal)
+- **Self-contained** - Minimal dependencies, small binary (~1.2MB budget as of #277; see PHILOSOPHY.md §4)
 - **Cross-platform** - Native, WASM, mobile, embedded
 - **Reliability over features** - Do less, do it perfectly
 - **Bi-temporal first-class** - Time travel is a core feature, not addon

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -109,7 +109,11 @@ SQLite's success comes from a clear philosophy: be a library, not a server. Be s
 - Pure Rust implementation
 - Minimal dependency tree (currently: serde, uuid, anyhow)
 - No required system libraries (optional backends OK)
-- Target: <1MB binary for core engine
+- Target: ~1.2MB budget for core engine (raised from the original <1MB goal for
+  #277's structured error codes — 130 documented codes across 6 categories
+  cannot fit in 1MB even with opt-level="z", LTO, codegen-units=1, and
+  strip=symbols all already applied; see CI's `binary-size.yml` for the
+  enforced limit)
 - No runtime dependencies (no JVM, no Python, no Node.js)
 
 **Anti-pattern**: Requiring external services, libraries, or runtimes to function.
@@ -360,7 +364,7 @@ You'll know Minigraf has succeeded when:
 1. ✅ **Ubiquity**: Developers say "just use Minigraf" for embedded graph storage
 2. ✅ **Trust**: Known for never losing data, crash-safe, reliable
 3. ✅ **Simplicity**: New users are productive in under 5 minutes
-4. ✅ **Size**: Core binary under 1MB, minimal dependencies
+4. ✅ **Size**: Core binary within its ~1.2MB budget, minimal dependencies
 5. ✅ **Portability**: Runs everywhere from Raspberry Pi to browsers
 6. ✅ **Stability**: API hasn't broken in years
 7. ✅ **Documentation**: Comprehensive docs with examples


### PR DESCRIPTION
## Summary
- The core release binary was already at the 1MB CI wire before #277's structured error codes rollout started (measured ~1034 KiB on a controlled local build).
- #360 (WAL, 6 codes) + #361 (QRY, 9 codes) together added only ~9 KiB — but that was enough to fail the binary-size check on PR #364.
- Investigated whether the historic fix (de-generifying `build_btree`, commit 981d868) applies again — it doesn't. `bail_coded!`/`err_coded!`/`format_template` are already non-generic (`&[&dyn fmt::Display]`), so there's no per-call-site monomorphization to cut. `cargo bloat` shows no single dominant symbol, just diffuse growth across ~2000 small functions.
- All existing size levers (`opt-level = "z"`, `lto = true`, `codegen-units = 1`, `strip = "symbols"`) are already at their most aggressive settings.
- Extrapolating to the full 130-code rollout (PRS: 79, STG: 27, WAL: 6, QRY: 9, API+INT: 9) projects ~60-70 KiB more growth, which the 1MB budget can't absorb.

Raises `SIZE_LIMIT_BYTES` in `.github/workflows/binary-size.yml` from 1048576 (1 MiB) to 1228800 (1200 KiB), and updates the stated target in `PHILOSOPHY.md` §4 and `CLAUDE.md` to match. This is a deliberate, user-approved deviation from the project's `<1MB` philosophy goal — documented in `CHANGELOG.md`.

Part of #277 (not a closing PR — does not close #277 or any of #358-#362).

## Test plan
- [x] `cargo test` — 725 passed, 0 failed
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-push hook (fmt+clippy+test) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)